### PR TITLE
chore: Set `PackageLicenseExpression` and fix incorrect datatype for container attach parameter

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
         <IncludeSymbols>true</IncludeSymbols>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>icon.png</PackageIcon>
     </PropertyGroup>
 

--- a/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -20,7 +20,7 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("detachKeys", false)]
         public string DetachKeys { get; set; }
 
-        [QueryStringParameter("logs", false)]
-        public string Logs { get; set; }
+        [QueryStringParameter("logs", false, typeof(BoolQueryStringConverter))]
+        public bool? Logs { get; set; }
     }
 }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -93,7 +93,7 @@ type ContainerAttachParameters struct {
 	Stdout     bool   `rest:"query"`
 	Stderr     bool   `rest:"query"`
 	DetachKeys string `rest:"query,detachKeys"`
-	Logs       string `rest:"query"`
+	Logs       bool   `rest:"query"`
 }
 
 // ContainerInspectParameters for GET /containers/(id)/json


### PR DESCRIPTION
The PR merges two minor changes and improvements from the upstream repository. It sets the MSBuild property `PackageLicenseExpression` and fixes an incorrect datatype for the container attach parameter API.