### PR TITLE
feat: Add query argument for container inspect API: `containers/{id}/json`

### DIFF
--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -64,6 +64,22 @@ internal class ContainerOperations : IContainerOperations
         return await _client.MakeRequestAsync<ContainerInspectResponse>(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/json", cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<ContainerInspectResponse> InspectContainerAsync(string id, ContainerInspectParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        IQueryString queryString = new QueryString<ContainerInspectParameters>(parameters);
+        return await _client.MakeRequestAsync<ContainerInspectResponse>(new[] { NoSuchContainerHandler }, HttpMethod.Get, $"containers/{id}/json", queryString, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<ContainerProcessesResponse> ListProcessesAsync(string id, ContainerListProcessesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
     {
         if (string.IsNullOrEmpty(id))

--- a/src/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -44,6 +44,20 @@ public interface IContainerOperations
     Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
 
     /// <summary>
+    /// Retrieves low-level information about a container with additional options.
+    /// </summary>
+    /// <param name="id">The ID or name of the container.</param>
+    /// <param name="parameters">Specifics of how to perform the operation, such as whether to include size information.</param>
+    /// <param name="cancellationToken">When triggered, the operation will stop at the next available time, if possible.</param>
+    /// <returns>A <see cref="Task{TResult}"/> that resolves to a <see cref="ContainerInspectResponse"/>, which holds details about the container.</returns>
+    /// <remarks>The corresponding commands in the Docker CLI are <c>docker inspect --size</c> and <c>docker container inspect --size</c>.</remarks>
+    /// <exception cref="DockerContainerNotFoundException">No such container was found.</exception>
+    /// <exception cref="ArgumentNullException">One or more of the inputs was <see langword="null"/>.</exception>
+    /// <exception cref="DockerApiException">the daemon experienced an error.</exception>
+    /// <exception cref="HttpRequestException">The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.</exception>
+    Task<ContainerInspectResponse> InspectContainerAsync(string id, ContainerInspectParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+    /// <summary>
     /// Retrieves a list of processes running within the container.
     /// </summary>
     /// <param name="id">The ID or name of the container.</param>


### PR DESCRIPTION
As per the the [issue on the original repo](https://github.com/dotnet/Docker.DotNet/issues/694).

# Problem
`ContainerInspectParameters.IncludeSize` was defined but never used, therefore, there were no way to get `SizeRootFs` and `SizeRw` values in the existing `InspectContainerAsync` operation.

# Solution
Created a `InspectContainerAsync` overload that also accepts `ContainerInspectParameters`