### PR TITLE
Add ImageOptions introduced in Docker Engine API 1.48

### DIFF
--- a/src/Docker.DotNet/Models/ImageOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageOptions.Generated.cs
@@ -1,0 +1,9 @@
+
+namespace Docker.DotNet.Models
+{
+    public class ImageOptions // (mount.ImageOptions)
+    {
+        [JsonPropertyName("Subpath")]
+        public string Subpath { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/Mount.Generated.cs
+++ b/src/Docker.DotNet/Models/Mount.Generated.cs
@@ -30,5 +30,8 @@ namespace Docker.DotNet.Models
 
         [JsonPropertyName("ClusterOptions")]
         public ClusterOptions ClusterOptions { get; set; }
+        
+        [JsonPropertyName("ImageOptions")]
+        public ImageOptions ImageOptions { get; set; }
     }
 }


### PR DESCRIPTION
Docker Engine API 1.48 introduced a new Mount Type for `Image`.
See https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerCreate
