### PR TITLE
fix: Use '/exec/(id)/start' param type and the correct chunk size in the HTTP request

### DIFF
--- a/src/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
+++ b/src/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
@@ -3,25 +3,14 @@ namespace Docker.DotNet.BasicAuth;
 internal class BasicAuthHandler : DelegatingHandler
 {
     private readonly MaybeSecureString _username;
+
     private readonly MaybeSecureString _password;
 
-    public BasicAuthHandler(MaybeSecureString username, MaybeSecureString password, HttpMessageHandler innerHandler) : base(innerHandler)
+    public BasicAuthHandler(MaybeSecureString username, MaybeSecureString password, HttpMessageHandler httpMessageHandler)
+        : base(httpMessageHandler)
     {
         _username = username.Copy();
         _password = password.Copy();
-    }
-
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", BuildParameters());
-
-        return base.SendAsync(request, cancellationToken);
-    }
-
-    private string BuildParameters()
-    {
-        var authInfo = $"{_username}:{_password}";
-        return Convert.ToBase64String(Encoding.UTF8.GetBytes(authInfo));
     }
 
     protected override void Dispose(bool disposing)
@@ -31,5 +20,7 @@ internal class BasicAuthHandler : DelegatingHandler
             _username.Dispose();
             _password.Dispose();
         }
+
+        base.Dispose(disposing);
     }
 }

--- a/src/Docker.DotNet/Endpoints/IExecOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IExecOperations.cs
@@ -2,66 +2,9 @@ namespace Docker.DotNet;
 
 public interface IExecOperations
 {
-    /// <summary>
-    /// Create an exec instance.
-    ///
-    /// Runs a command inside a running container.
-    /// </summary>
-    /// <remarks>
-    /// docker exec
-    /// docker container exec
-    ///
-    /// 201 - No error.
-    /// 404 - No such container.
-    /// 409 - Container is paused.
-    /// 500 - Server error.
-    /// </remarks>
-    /// <param name="id">ID or name of the container.</param>
-    Task<ContainerExecCreateResponse> ExecCreateContainerAsync(string id, ContainerExecCreateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+    Task<ContainerExecInspectResponse> InspectContainerExecAsync(string id, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Start an exec instance.
-    ///
-    /// Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting
-    /// the command. Otherwise, it sets up an interactive session with the command.
-    /// </summary>
-    /// <remarks>
-    /// 204 - No error.
-    /// 404 - No such exec instance.
-    /// 500 - Server error.
-    /// </remarks>
-    /// <param name="id">Exec instance ID.</param>
-    Task StartContainerExecAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+    Task<ContainerExecCreateResponse> CreateContainerExecAsync(string id, ContainerExecCreateParameters parameters, CancellationToken cancellationToken = default);
 
-    Task<MultiplexedStream> StartAndAttachContainerExecAsync(string id, bool tty, CancellationToken cancellationToken = default(CancellationToken));
-
-    Task<MultiplexedStream> StartWithConfigContainerExecAsync(string id, ContainerExecStartParameters eConfig, CancellationToken cancellationToken = default(CancellationToken));
-
-    /// <summary>
-    /// Resize an exec instance.
-    ///
-    /// Resize the TTY session used by an exec instance. This endpoint only works if {tty} was specified as part of
-    /// creating and starting the exec instance.
-    /// </summary>
-    /// <remarks>
-    /// 201 - No error.
-    /// 404 - No such exec instance.
-    /// </remarks>
-    /// <param name="id">Exec instance ID.</param>
-    Task ResizeContainerExecTtyAsync(string id, ContainerResizeParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
-
-    /// <summary>
-    /// Inspect an exec instance.
-    ///
-    /// Return low-level information about an exec instance.
-    /// </summary>
-    /// <remarks>
-    /// docker inspect
-    ///
-    /// 200 - No error.
-    /// 404 - No such exec instance.
-    /// 500 - Server error.
-    /// </remarks>
-    /// <param name="id">Exec instance ID.</param>
-    Task<ContainerExecInspectResponse> InspectContainerExecAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+    Task<MultiplexedStream> StartContainerExecAsync(string id, ContainerExecStartParameters parameters, CancellationToken cancellationToken = default);
 }

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
@@ -59,18 +59,17 @@ internal sealed class BufferedReadStream : WriteClosableStream, IPeekableStream
 
     protected override void Dispose(bool disposing)
     {
-        // TODO: Why does disposing break the implementation, see the other chunked streams too.
-        // base.Dispose(disposing);
-
         if (disposing)
         {
-            _inner.Dispose();
-
             if (Interlocked.Decrement(ref _bufferRefCount) == 0)
             {
                 ArrayPool<byte>.Shared.Return(_buffer);
             }
+
+            _inner.Dispose();
         }
+
+        base.Dispose(disposing);
     }
 
     public override long Seek(long offset, SeekOrigin origin)

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedReadStream.cs
@@ -66,16 +66,6 @@ internal sealed class ChunkedReadStream : Stream
         }
     }
 
-    protected override void Dispose(bool disposing)
-    {
-        // base.Dispose(disposing);
-
-        if (disposing)
-        {
-            // _inner.Dispose();
-        }
-    }
-
     public override int Read(byte[] buffer, int offset, int count)
     {
         throw new NotSupportedException();

--- a/src/Docker.DotNet/Models/ContainerExecStartParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecStartParameters.Generated.cs
@@ -1,44 +1,16 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Docker.DotNet.Models
 {
     public class ContainerExecStartParameters // (main.ContainerExecStartParameters)
     {
-        [JsonPropertyName("User")]
-        public string User { get; set; }
-
-        [JsonPropertyName("Privileged")]
-        public bool Privileged { get; set; }
+        [JsonPropertyName("Detach")]
+        public bool Detach { get; set; }
 
         [JsonPropertyName("Tty")]
         public bool Tty { get; set; }
 
         [JsonPropertyName("ConsoleSize")]
         public ulong[] ConsoleSize { get; set; }
-
-        [JsonPropertyName("AttachStdin")]
-        public bool AttachStdin { get; set; }
-
-        [JsonPropertyName("AttachStderr")]
-        public bool AttachStderr { get; set; }
-
-        [JsonPropertyName("AttachStdout")]
-        public bool AttachStdout { get; set; }
-
-        [JsonPropertyName("Detach")]
-        public bool Detach { get; set; }
-
-        [JsonPropertyName("DetachKeys")]
-        public string DetachKeys { get; set; }
-
-        [JsonPropertyName("Env")]
-        public IList<string> Env { get; set; }
-
-        [JsonPropertyName("WorkingDir")]
-        public string WorkingDir { get; set; }
-
-        [JsonPropertyName("Cmd")]
-        public IList<string> Cmd { get; set; }
     }
 }

--- a/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
@@ -728,8 +728,8 @@ public class IContainerOperationsTests
         _ = await _testFixture.DockerClient.Containers.StartContainerAsync(createContainerResponse.ID, new ContainerStartParameters());
 
         // When
-        var containerExecCreateResponse = await _testFixture.DockerClient.Exec.ExecCreateContainerAsync(createContainerResponse.ID, containerExecCreateParameters);
-        using var stream = await _testFixture.DockerClient.Exec.StartWithConfigContainerExecAsync(containerExecCreateResponse.ID, containerExecStartParameters);
+        var containerExecCreateResponse = await _testFixture.DockerClient.Exec.CreateContainerExecAsync(createContainerResponse.ID, containerExecCreateParameters);
+        using var stream = await _testFixture.DockerClient.Exec.StartContainerExecAsync(containerExecCreateResponse.ID, containerExecStartParameters);
 
         var buffer = new byte[] { 10 };
         var exception = await Record.ExceptionAsync(() => stream.WriteAsync(buffer, 0, buffer.Length, _testFixture.Cts.Token));

--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -94,7 +94,7 @@ public class ISystemOperationsTests
 
         await cts.CancelAsync();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
 
         Assert.True(wasProgressCalled);
     }
@@ -239,7 +239,7 @@ public class ISystemOperationsTests
         await Task.Delay(TimeSpan.FromSeconds(1));
         await cts.CancelAsync();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
 
         Assert.Equal(2, progressCalledCounter);
         Assert.True(task.IsCanceled);

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -188,7 +188,7 @@ type ContainerExecCreateParameters container.ExecOptions
 type ContainerExecCreateResponse types.IDResponse
 
 // ContainerExecStartParameters for POST /exec/(id)/start
-type ContainerExecStartParameters container.ExecOptions
+type ContainerExecStartParameters container.ExecStartOptions
 
 // ImagesCreateParameters for POST /images/create
 type ImagesCreateParameters struct {


### PR DESCRIPTION
The model definition used the wrong type for the Docker Engine API `/exec/(id)/start`. The PR  replaces the incorrect type, `ExecOptions`, with the correct type, `ExecStartOptions`, as specified in the Docker Engine API documentation.