### PR TITLE
chore: Remove information that this project runs under the .NET Foundation

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,6 +1,0 @@
-# Code of Conduct
-
-This project has adopted the code of conduct defined by the Contributor Covenant
-to clarify expected behavior in our community.
-
-For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -248,30 +248,6 @@ Here are typical exceptions thrown from the client library:
 * **`ArgumentNullException`** is thrown when one of the required parameters are missing/empty.
     * Consider reading the [Docker Remote API reference][docker-remote-api] and source code of the corresponding method you are going to use in from this library. This way you can easily find out which parameters are required and their format.
 
-## .NET Foundation
-
-Docker.DotNet is a [.NET Foundation](https://www.dotnetfoundation.org) project.
-
-There are many .NET related projects on GitHub.
-
-- [.NET home repo](https://github.com/Microsoft/dotnet) - links to 100s of .NET projects, from Microsoft and the community.
-- [ASP.NET Core home](https://docs.microsoft.com/aspnet/core) - the best place to start learning about ASP.NET Core.
-
-This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct).
-
-General .NET OSS discussions: [.NET Foundation Discord](https://dotnetfoundation.org/socialize/discord)
-
-## Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.dotnetfoundation.org.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-
 ## License
 
 Docker.DotNet is licensed under the [MIT](LICENSE) license.

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/UnixDomainSocketEndPoint.cs
@@ -1,7 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE-MIT.txt file for more information.
-
 namespace Microsoft.Net.Http.Client;
 
 internal sealed class UnixDomainSocketEndPoint : EndPoint

--- a/tools/specgen/LICENSE
+++ b/tools/specgen/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) .NET Foundation and Contributors
+Copyright (c) Andre Hofmeister
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I've tried to continue to maintain Docker.DotNet under the .NET Foundation by becoming a member and project owner over the past few years. Unfortunately, it's been very difficult, with too many obstacles along the way. The amount of time I've spent on this isn't worth it, especially when there are other ways to continue the great work of Docker.DotNet.

This PR updates the repository by removing the reference to the .NET Foundation, as this fork is no longer part of it.

As a follow-up, we'll need to add guidelines regarding the code of conduct and contributions back to the repository. Probably something similar to what we use in Testcontainers for .NET.