### PR TITLE
fix: Dispose HttpMessageHandler

### DIFF
--- a/src/Docker.DotNet.X509/X509Certificate2.cs
+++ b/src/Docker.DotNet.X509/X509Certificate2.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+#if NETSTANDARD
 namespace Docker.DotNet.X509.Polyfills;
 
 using Org.BouncyCastle.Crypto;

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -32,8 +32,8 @@ public class DockerClientConfiguration : IDisposable
 
         EndpointBaseUri = endpoint;
         Credentials = credentials ?? new AnonymousCredentials();
-        DefaultTimeout = TimeSpan.Equals(default, defaultTimeout) ? TimeSpan.FromSeconds(100) : defaultTimeout;
-        NamedPipeConnectTimeout = TimeSpan.Equals(default, namedPipeConnectTimeout) ? TimeSpan.FromMilliseconds(100) : namedPipeConnectTimeout;
+        DefaultTimeout = TimeSpan.Equals(TimeSpan.Zero, defaultTimeout) ? TimeSpan.FromSeconds(100) : defaultTimeout;
+        NamedPipeConnectTimeout = TimeSpan.Equals(TimeSpan.Zero, namedPipeConnectTimeout) ? TimeSpan.FromMilliseconds(100) : namedPipeConnectTimeout;
         DefaultHttpRequestHeaders = defaultHttpRequestHeaders ?? new Dictionary<string, string>();
     }
 

--- a/src/Docker.DotNet/DockerPipeStream.cs
+++ b/src/Docker.DotNet/DockerPipeStream.cs
@@ -126,8 +126,8 @@ internal class DockerPipeStream : WriteClosableStream, IPeekableStream
     {
         if (disposing)
         {
-            _stream.Dispose();
             _event.Dispose();
+            _stream.Dispose();
         }
     }
 }

--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -1,4 +1,4 @@
-﻿namespace Docker.DotNet;
+namespace Docker.DotNet;
 
 internal class ContainerOperations : IContainerOperations
 {

--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -1,4 +1,4 @@
-namespace Docker.DotNet;
+﻿namespace Docker.DotNet;
 
 internal class ContainerOperations : IContainerOperations
 {
@@ -318,7 +318,7 @@ internal class ContainerOperations : IContainerOperations
             throw new ArgumentNullException(nameof(id));
         }
 
-        return await _client.MakeRequestAsync<ContainerWaitResponse>(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/wait", null, null, null, TimeSpan.FromMilliseconds(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
+        return await _client.MakeRequestAsync<ContainerWaitResponse>(new[] { NoSuchContainerHandler }, HttpMethod.Post, $"containers/{id}/wait", null, null, null, Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
     }
 
     public Task RemoveContainerAsync(string id, ContainerRemoveParameters parameters, CancellationToken cancellationToken = default)

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
@@ -63,6 +63,7 @@ public class HttpConnectionResponseContent : HttpContent
             if (disposing)
             {
                 _responseStream.Dispose();
+                _connection.Dispose();
             }
         }
         finally

--- a/test/Docker.DotNet.Tests/CommonCommands.cs
+++ b/test/Docker.DotNet.Tests/CommonCommands.cs
@@ -1,4 +1,4 @@
-﻿namespace Docker.DotNet.Tests;
+namespace Docker.DotNet.Tests;
 
 public static class CommonCommands
 {

--- a/test/Docker.DotNet.Tests/xunit.runner.json
+++ b/test/Docker.DotNet.Tests/xunit.runner.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "diagnosticMessages" : false
 }


### PR DESCRIPTION
The `HttpConnectionResponseContent` did not dispose of the underlying connection (the `HttpMessageHandler`). Disposing of the instances also disposes of the connection.