### PR TITLE
chore: Add ServerCertificateValidationCallback property again

### DIFF
--- a/src/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/src/Docker.DotNet.X509/CertificateCredentials.cs
@@ -11,6 +11,8 @@ public class CertificateCredentials : Credentials
         _certificate = certificate;
     }
 
+    public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
+
     public override void Dispose()
     {
         Dispose(true);
@@ -24,11 +26,17 @@ public class CertificateCredentials : Credentials
 
     public override HttpMessageHandler GetHandler(HttpMessageHandler handler)
     {
-        if (handler is HttpClientHandler httpClientHandler)
+        if (handler is not ManagedHandler managedHandler)
         {
-            httpClientHandler.ClientCertificates.Add(_certificate);
-            httpClientHandler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+            return handler;
         }
+
+        if (!managedHandler.ClientCertificates.Contains(_certificate))
+        {
+            managedHandler.ClientCertificates.Add(_certificate);
+        }
+
+        managedHandler.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
 
         return handler;
     }

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/RequestExtensions.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/RequestExtensions.cs
@@ -87,7 +87,7 @@ internal static class RequestExtensions
 #if NET6_0_OR_GREATER
         return request.Options.TryGetValue(new HttpRequestOptionsKey<T>(key), out var obj) ? obj : default;
 #else
-            return request.Properties.TryGetValue(key, out var obj) ? (T)obj : default;
+        return request.Properties.TryGetValue(key, out var obj) ? (T)obj : default;
 #endif
     }
 
@@ -96,7 +96,7 @@ internal static class RequestExtensions
 #if NET6_0_OR_GREATER
         request.Options.Set(new HttpRequestOptionsKey<T>(key), value);
 #else
-            request.Properties[key] = value;
+        request.Properties[key] = value;
 #endif
     }
 }


### PR DESCRIPTION
This PR adds the `ServerCertificateValidationCallback` property again. At first, I thought it would be enough to just override the `CertificateCredentials` class, but it turns out it's simpler to keep the property and stick with the old behavior.