### PR TITLE
fix: Don't set the Connection header to 'close' if it is already set

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -386,8 +386,8 @@ public sealed class DockerClient : IDockerClient
             headers = new Dictionary<string, string>();
         }
 
-        headers.Add("Connection", "tcp");
-        headers.Add("Upgrade", "Upgrade");
+        headers.Add("Upgrade", "tcp");
+        headers.Add("Connection", "Upgrade");
 
         var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -141,7 +141,7 @@ public class ManagedHandler : HttpMessageHandler
 
         ProcessUrl(request);
         ProcessHostHeader(request);
-        request.Headers.ConnectionClose = true; // TODO: Connection re-use is not supported.
+        request.Headers.ConnectionClose = !request.Headers.Contains("Connection"); // TODO: Connection reuse is not supported.
 
         ProxyMode proxyMode = DetermineProxyModeAndAddressLine(request);
         Socket socket;


### PR DESCRIPTION
Use correct headers and values to request connection upgrade for hijacking streams, ref
<https://docs.docker.com/reference/api/engine/version/v1.50/#tag/Container/operation/ContainerAttach>.

Also modify the `Connection` header to not close unless specifically requested.