### PR TITLE
fix: Set auth header in basic auth handler implementation

### DIFF
--- a/src/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
+++ b/src/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
@@ -6,11 +6,27 @@ internal class BasicAuthHandler : DelegatingHandler
 
     private readonly MaybeSecureString _password;
 
+    private readonly Lazy<AuthenticationHeaderValue> _authHeader;
+
     public BasicAuthHandler(MaybeSecureString username, MaybeSecureString password, HttpMessageHandler httpMessageHandler)
         : base(httpMessageHandler)
     {
         _username = username.Copy();
         _password = password.Copy();
+
+        _authHeader = new Lazy<AuthenticationHeaderValue>(() =>
+        {
+            var credentials = $"{_username}:{_password}";
+            var bytes = Encoding.ASCII.GetBytes(credentials);
+            var base64 = Convert.ToBase64String(bytes);
+            return new AuthenticationHeaderValue("Basic", base64);
+        });
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Headers.Authorization = _authHeader.Value;
+        return base.SendAsync(request, cancellationToken);
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
The previous implementation set the auth header for the HTTP request message. It looks like this was unintentionally removed, and this PR reverts that change. Closes #27.