### PR TITLE
fix: Return string instead of JSON content

### DIFF
--- a/src/Docker.DotNet/JsonRequestContent.cs
+++ b/src/Docker.DotNet/JsonRequestContent.cs
@@ -23,6 +23,6 @@ internal class JsonRequestContent<T> : IRequestContent
 
     public HttpContent GetContent()
     {
-        return _serializer.GetJsonContent(_value);
+        return _serializer.GetHttpContent(_value);
     }
 }

--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -4,6 +4,10 @@ internal sealed class JsonSerializer
 {
     private readonly JsonSerializerOptions _options = new JsonSerializerOptions();
 
+    static JsonSerializer()
+    {
+    }
+
     private JsonSerializer()
     {
         _options.Converters.Add(new JsonEnumMemberConverter<RestartPolicyKind>());
@@ -16,7 +20,7 @@ internal sealed class JsonSerializer
     public static JsonSerializer Instance { get; }
         = new JsonSerializer();
 
-    public HttpContent GetJsonContent<T>(T value)
+    public HttpContent GetHttpContent<T>(T value)
     {
         return new StringContent(Serialize(value), Encoding.UTF8, "application/json");
     }

--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -18,7 +18,7 @@ internal sealed class JsonSerializer
 
     public HttpContent GetJsonContent<T>(T value)
     {
-        return JsonContent.Create(value, options: _options);
+        return new StringContent(Serialize(value), Encoding.UTF8, "application/json");
     }
 
     public string Serialize<T>(T value)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.128.3",
+  "version": "3.128.4",
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
While looking into the issue https://github.com/testcontainers/Docker.DotNet/issues/11#issuecomment-3168272264, I noticed the root cause seems to be related to this PR #6. After carefully reviewing the diff, I didn't see anything obviously wrong, so I started reverting a few changes. Thats when I noticed that using `StringContent(string, Encoding?, string?)` instead of `JsonContent.Create(T, JsonSerializerOptions?)` seems to fix the issue.

Im still not entirely sure if this fully resolves the issue or what the exact root cause is. Im trying to dig deeper. In the meantime, I'd like to open a PR so others can validate and test it.

My guess is that the problem lies somewhere internally in how `JsonContent` handles connections, possibly causing an incompatibility with Docker.DotNet's custom HTTP client.

- Relates #11
- Relates #31 (maybe)
- Relates #28 (maybe)

## Follow-ups

- Add a GitHub workflow that runs tests against Podman (CI).