### PR TITLE
feat: add option to use native dotnet http handler for http(s)

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -34,7 +34,7 @@ public sealed class DockerClient : IDockerClient
         Plugin = new PluginOperations(this);
         Exec = new ExecOperations(this);
 
-        ManagedHandler handler;
+        HttpMessageHandler handler;
         var uri = Configuration.EndpointBaseUri;
         switch (uri.Scheme.ToLowerInvariant())
         {
@@ -80,11 +80,17 @@ public sealed class DockerClient : IDockerClient
                     Scheme = configuration.Credentials.IsTlsCredentials() ? "https" : "http"
                 };
                 uri = builder.Uri;
-                handler = new ManagedHandler(logger);
+                if (configuration.NativeHttpHandler)
+                    handler = new HttpClientHandler();
+                else
+                    handler = new ManagedHandler(logger);
                 break;
 
             case "https":
-                handler = new ManagedHandler(logger);
+                if (configuration.NativeHttpHandler)
+                    handler = new HttpClientHandler();
+                else
+                    handler = new ManagedHandler(logger);
                 break;
 
             case "unix":

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -8,8 +8,9 @@ public class DockerClientConfiguration : IDisposable
         Credentials credentials = null,
         TimeSpan defaultTimeout = default,
         TimeSpan namedPipeConnectTimeout = default,
-        IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null)
-        : this(GetLocalDockerEndpoint(), credentials, defaultTimeout, namedPipeConnectTimeout, defaultHttpRequestHeaders)
+        IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null,
+        bool nativeHttpHandler = false)
+        : this(GetLocalDockerEndpoint(), credentials, defaultTimeout, namedPipeConnectTimeout, defaultHttpRequestHeaders, nativeHttpHandler)
     {
     }
 
@@ -18,7 +19,8 @@ public class DockerClientConfiguration : IDisposable
         Credentials credentials = null,
         TimeSpan defaultTimeout = default,
         TimeSpan namedPipeConnectTimeout = default,
-        IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null)
+        IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null,
+        bool nativeHttpHandler = false)
     {
         if (endpoint == null)
         {
@@ -35,6 +37,7 @@ public class DockerClientConfiguration : IDisposable
         DefaultTimeout = TimeSpan.Equals(TimeSpan.Zero, defaultTimeout) ? TimeSpan.FromSeconds(100) : defaultTimeout;
         NamedPipeConnectTimeout = TimeSpan.Equals(TimeSpan.Zero, namedPipeConnectTimeout) ? TimeSpan.FromMilliseconds(100) : namedPipeConnectTimeout;
         DefaultHttpRequestHeaders = defaultHttpRequestHeaders ?? new Dictionary<string, string>();
+        NativeHttpHandler = nativeHttpHandler;
     }
 
     /// <summary>
@@ -49,6 +52,8 @@ public class DockerClientConfiguration : IDisposable
     public TimeSpan DefaultTimeout { get; }
 
     public TimeSpan NamedPipeConnectTimeout { get; }
+
+    public bool NativeHttpHandler { get; }
 
     public DockerClient CreateClient(Version requestedApiVersion = null, ILogger logger = null)
     {

--- a/test/Docker.DotNet.Tests/TestFixture.cs
+++ b/test/Docker.DotNet.Tests/TestFixture.cs
@@ -21,7 +21,7 @@ public sealed class TestFixture : Progress<JSONMessage>, IAsyncLifetime, IDispos
     public TestFixture(IMessageSink messageSink)
     {
         _messageSink = messageSink;
-        DockerClientConfiguration = new DockerClientConfiguration();
+        DockerClientConfiguration = new DockerClientConfiguration(nativeHttpHandler: true);
         DockerClient = DockerClientConfiguration.CreateClient(logger: this);
         Cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         Cts.Token.Register(() => throw new TimeoutException("Docker.DotNet tests timed out."));


### PR DESCRIPTION
Try to use standard dotnet http handler instead of custom one.
But WindowsPipe and UnixSockets not working with this one.