### PR TITLE
Reduce unnecessarily high StringBuilder capacity

### DIFF
--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
@@ -159,7 +159,7 @@ internal sealed class BufferedReadStream : WriteClosableStream, IPeekableStream
 
     public async Task<string> ReadLineAsync(CancellationToken cancellationToken)
     {
-        var line = new StringBuilder(_buffer.Length);
+        var line = new StringBuilder();
 
         var crIndex = -1;
 


### PR DESCRIPTION
I've been doing some profiling and saw some extremely high allocations when just starting and stopping a container with `Testcontainers.Mariadb`. There are around 800 allocations of `char[]` with a length of 8192 every time you start a container and they are all coming from `BufferedReadStream.ReadLineAsync`.

`_buffer.Length` is by default always 8192 which is way too high. Passing that value into the constructor of the `StringBuilder` makes it allocate a `char[]` of that length. The length of the string the builder is creating is actually around 16 to 20 chars. The default capacity of `StringBuilder` is 16 ([dotnet/runtime](https://github.com/dotnet/runtime/blob/0722618d671cb551d9de826d270ce7825da49cab/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs#L60)), so the parameter can just be removed.

The below code shows a reduction in allocations when starting and stopping a container from around 7.7MB to 950KB.
This will probably affect and improve all the packages and not only `Testcontainers.Mariadb`. 🙂 

```csharp
private static async Task Main()
{
    while (true)
    {
        long bytes = GC.GetTotalAllocatedBytes();
        await StartContainerAsync();
        long allocated = GC.GetTotalAllocatedBytes() - bytes;
        Console.WriteLine(allocated);
    }
}

private static async Task StartContainerAsync()
{
    MariaDbBuilder builder = new();
    MariaDbContainer container = builder.Build();
    await container.StartAsync();
    await container.StopAsync();
}
```