### PR TITLE
feat: Add copy to container query parameters

### DIFF
--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -366,7 +366,7 @@ internal class ContainerOperations : IContainerOperations
         };
     }
 
-    public Task ExtractArchiveToContainerAsync(string id, ContainerPathStatParameters parameters, Stream stream, CancellationToken cancellationToken = default)
+    public Task ExtractArchiveToContainerAsync(string id, CopyToContainerParameters parameters, Stream stream, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(id))
         {
@@ -378,7 +378,7 @@ internal class ContainerOperations : IContainerOperations
             throw new ArgumentNullException(nameof(parameters));
         }
 
-        IQueryString queryParameters = new QueryString<ContainerPathStatParameters>(parameters);
+        IQueryString queryParameters = new QueryString<CopyToContainerParameters>(parameters);
 
         var data = new BinaryRequestContent(stream, "application/x-tar");
         return _client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Put, $"containers/{id}/archive", queryParameters, data, cancellationToken);

--- a/src/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -368,7 +368,7 @@ public interface IContainerOperations
     /// <exception cref="DockerApiException">Permission is denied (the volume or container rootfs is marked read-only),
     /// the input is invalid, or the daemon experienced an error.</exception>
     /// <exception cref="HttpRequestException">The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.</exception>
-    Task ExtractArchiveToContainerAsync(string id, ContainerPathStatParameters parameters, Stream stream, CancellationToken cancellationToken = default);
+    Task ExtractArchiveToContainerAsync(string id, CopyToContainerParameters parameters, Stream stream, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes stopped containers.

--- a/src/Docker.DotNet/Models/CopyToContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CopyToContainerParameters.Generated.cs
@@ -1,0 +1,15 @@
+
+namespace Docker.DotNet.Models
+{
+    public class CopyToContainerParameters // (main.CopyToContainerParameters)
+    {
+        [QueryStringParameter("path", true)]
+        public string Path { get; set; }
+
+        [QueryStringParameter("noOverwriteDirNonDir", false, typeof(BoolQueryStringConverter))]
+        public bool? AllowOverwriteDirWithFile { get; set; }
+
+        [QueryStringParameter("copyUIDGID", false, typeof(BoolQueryStringConverter))]
+        public bool? CopyUIDGID { get; set; }
+    }
+}

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -86,6 +86,13 @@ type ContainerPathStatParameters struct {
 	Path string `rest:"query,path,required"`
 }
 
+// CopyToContainerParameters for PUT /containers/(id)/archive
+type CopyToContainerParameters struct {
+	Path                      string `rest:"query,path,required"`
+	AllowOverwriteDirWithFile bool   `rest:"query,noOverwriteDirNonDir"`
+	CopyUIDGID                bool   `rest:"query,copyUIDGID"`
+}
+
 // ContainerAttachParameters for POST /containers/(id)/attach
 type ContainerAttachParameters struct {
 	Stream     bool   `rest:"query"`

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -200,6 +200,9 @@ var dockerTypesToReflect = []reflect.Type{
 	reflect.TypeOf(ContainerPathStatParameters{}),
 	reflect.TypeOf(container.PathStat{}),
 
+	// PUT /containers/(id)/archive
+	reflect.TypeOf(CopyToContainerParameters{}),
+
 	// POST /containers/(id)/attach
 	reflect.TypeOf(ContainerAttachParameters{}),
 
@@ -207,11 +210,6 @@ var dockerTypesToReflect = []reflect.Type{
 
 	// GET /containers/(id)/changes
 	reflect.TypeOf(container.FilesystemChange{}),
-
-	// OBSOLETE - POST /containers/(id)/copy
-
-	// GET /containers/(id)/export
-	// TODO: TAR Stream
 
 	// POST /containers/(id)/exec
 	reflect.TypeOf(ContainerExecCreateParameters{}),


### PR DESCRIPTION
This PR adds the missing parameters for extracting a set of files or directories to a directory in a container ([`/containers/{id}/archive`](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/PutContainerArchive)). Until now, the API did not support all available query parameters, specifically `noOverwriteDirNonDir` and `copyUIDGID`.