### PR TITLE
chore: Remove global usings from generated model classes

### DIFF
--- a/src/Docker.DotNet/Models/Actor.Generated.cs
+++ b/src/Docker.DotNet/Models/Actor.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Actor // (events.Actor)

--- a/src/Docker.DotNet/Models/Address.Generated.cs
+++ b/src/Docker.DotNet/Models/Address.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Address // (network.Address)

--- a/src/Docker.DotNet/Models/Annotations.Generated.cs
+++ b/src/Docker.DotNet/Models/Annotations.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Annotations // (swarm.Annotations)

--- a/src/Docker.DotNet/Models/AppArmorOpts.Generated.cs
+++ b/src/Docker.DotNet/Models/AppArmorOpts.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class AppArmorOpts // (swarm.AppArmorOpts)

--- a/src/Docker.DotNet/Models/AttestationProperties.Generated.cs
+++ b/src/Docker.DotNet/Models/AttestationProperties.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class AttestationProperties // (image.AttestationProperties)

--- a/src/Docker.DotNet/Models/AuthConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/AuthConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class AuthConfig // (registry.AuthConfig)

--- a/src/Docker.DotNet/Models/AuthResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/AuthResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class AuthResponse // (registry.AuthenticateOKBody)

--- a/src/Docker.DotNet/Models/BindOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/BindOptions.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class BindOptions // (mount.BindOptions)

--- a/src/Docker.DotNet/Models/BlkioStatEntry.Generated.cs
+++ b/src/Docker.DotNet/Models/BlkioStatEntry.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class BlkioStatEntry // (container.BlkioStatEntry)

--- a/src/Docker.DotNet/Models/BlkioStats.Generated.cs
+++ b/src/Docker.DotNet/Models/BlkioStats.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class BlkioStats // (container.BlkioStats)

--- a/src/Docker.DotNet/Models/CAConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/CAConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CAConfig // (swarm.CAConfig)

--- a/src/Docker.DotNet/Models/CPUStats.Generated.cs
+++ b/src/Docker.DotNet/Models/CPUStats.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CPUStats // (container.CPUStats)

--- a/src/Docker.DotNet/Models/CPUUsage.Generated.cs
+++ b/src/Docker.DotNet/Models/CPUUsage.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CPUUsage // (container.CPUUsage)

--- a/src/Docker.DotNet/Models/CapacityRange.Generated.cs
+++ b/src/Docker.DotNet/Models/CapacityRange.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CapacityRange // (volume.CapacityRange)

--- a/src/Docker.DotNet/Models/ClusterInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/ClusterInfo.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ClusterInfo // (swarm.ClusterInfo)

--- a/src/Docker.DotNet/Models/ClusterOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/ClusterOptions.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ClusterOptions // (mount.ClusterOptions)

--- a/src/Docker.DotNet/Models/ClusterVolume.Generated.cs
+++ b/src/Docker.DotNet/Models/ClusterVolume.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ClusterVolume // (volume.ClusterVolume)

--- a/src/Docker.DotNet/Models/ClusterVolumeSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/ClusterVolumeSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ClusterVolumeSpec // (volume.ClusterVolumeSpec)

--- a/src/Docker.DotNet/Models/Commit.Generated.cs
+++ b/src/Docker.DotNet/Models/Commit.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Commit // (system.Commit)

--- a/src/Docker.DotNet/Models/CommitContainerChangesParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CommitContainerChangesParameters.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CommitContainerChangesParameters // (main.CommitContainerChangesParameters)

--- a/src/Docker.DotNet/Models/CommitContainerChangesResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/CommitContainerChangesResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CommitContainerChangesResponse // (main.CommitContainerChangesResponse)

--- a/src/Docker.DotNet/Models/ComponentVersion.Generated.cs
+++ b/src/Docker.DotNet/Models/ComponentVersion.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ComponentVersion // (types.ComponentVersion)

--- a/src/Docker.DotNet/Models/Config.Generated.cs
+++ b/src/Docker.DotNet/Models/Config.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Config // (container.Config)

--- a/src/Docker.DotNet/Models/ConfigReference.Generated.cs
+++ b/src/Docker.DotNet/Models/ConfigReference.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ConfigReference // (network.ConfigReference)

--- a/src/Docker.DotNet/Models/ConfigReferenceFileTarget.Generated.cs
+++ b/src/Docker.DotNet/Models/ConfigReferenceFileTarget.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ConfigReferenceFileTarget // (swarm.ConfigReferenceFileTarget)

--- a/src/Docker.DotNet/Models/ConfigReferenceRuntimeTarget.Generated.cs
+++ b/src/Docker.DotNet/Models/ConfigReferenceRuntimeTarget.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ConfigReferenceRuntimeTarget // (swarm.ConfigReferenceRuntimeTarget)

--- a/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerAttachParameters // (main.ContainerAttachParameters)

--- a/src/Docker.DotNet/Models/ContainerEventsParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerEventsParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerEventsParameters // (main.ContainerEventsParameters)

--- a/src/Docker.DotNet/Models/ContainerExecCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecCreateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerExecCreateParameters // (main.ContainerExecCreateParameters)

--- a/src/Docker.DotNet/Models/ContainerExecCreateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecCreateResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerExecCreateResponse // (main.ContainerExecCreateResponse)

--- a/src/Docker.DotNet/Models/ContainerExecInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecInspectResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerExecInspectResponse // (container.ExecInspect)

--- a/src/Docker.DotNet/Models/ContainerExecStartParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecStartParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerExecStartParameters // (main.ContainerExecStartParameters)

--- a/src/Docker.DotNet/Models/ContainerFileSystemChangeResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerFileSystemChangeResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerFileSystemChangeResponse // (container.FilesystemChange)

--- a/src/Docker.DotNet/Models/ContainerInspectParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerInspectParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerInspectParameters // (main.ContainerInspectParameters)

--- a/src/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerInspectResponse // (container.InspectResponse)

--- a/src/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerJSONBase // (container.ContainerJSONBase)

--- a/src/Docker.DotNet/Models/ContainerKillParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerKillParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerKillParameters // (main.ContainerKillParameters)

--- a/src/Docker.DotNet/Models/ContainerListProcessesParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerListProcessesParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerListProcessesParameters // (main.ContainerListProcessesParameters)

--- a/src/Docker.DotNet/Models/ContainerListResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerListResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerListResponse // (container.Summary)

--- a/src/Docker.DotNet/Models/ContainerLogsParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerLogsParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerLogsParameters // (main.ContainerLogsParameters)

--- a/src/Docker.DotNet/Models/ContainerPathStatParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerPathStatParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerPathStatParameters // (main.ContainerPathStatParameters)

--- a/src/Docker.DotNet/Models/ContainerPathStatResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerPathStatResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerPathStatResponse // (container.PathStat)

--- a/src/Docker.DotNet/Models/ContainerProcessesResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerProcessesResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerProcessesResponse // (container.TopResponse)

--- a/src/Docker.DotNet/Models/ContainerRemoveParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerRemoveParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerRemoveParameters // (main.ContainerRemoveParameters)

--- a/src/Docker.DotNet/Models/ContainerRenameParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerRenameParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerRenameParameters // (main.ContainerRenameParameters)

--- a/src/Docker.DotNet/Models/ContainerResizeParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerResizeParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerResizeParameters // (main.ContainerResizeParameters)

--- a/src/Docker.DotNet/Models/ContainerRestartParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerRestartParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerRestartParameters // (main.ContainerRestartParameters)

--- a/src/Docker.DotNet/Models/ContainerSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerSpec // (swarm.ContainerSpec)

--- a/src/Docker.DotNet/Models/ContainerStartParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerStartParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerStartParameters // (main.ContainerStartParameters)

--- a/src/Docker.DotNet/Models/ContainerStatsParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerStatsParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerStatsParameters // (main.ContainerStatsParameters)

--- a/src/Docker.DotNet/Models/ContainerStatsResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerStatsResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerStatsResponse // (container.StatsResponse)

--- a/src/Docker.DotNet/Models/ContainerStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerStatus.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerStatus // (swarm.ContainerStatus)

--- a/src/Docker.DotNet/Models/ContainerStopParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerStopParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ContainerStopParameters // (main.ContainerStopParameters)

--- a/src/Docker.DotNet/Models/ContainerUpdateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerUpdateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerUpdateParameters // (main.ContainerUpdateParameters)

--- a/src/Docker.DotNet/Models/ContainerUpdateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerUpdateResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerUpdateResponse // (main.ContainerUpdateResponse)

--- a/src/Docker.DotNet/Models/ContainerWaitResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerWaitResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerWaitResponse // (main.ContainerWaitResponse)

--- a/src/Docker.DotNet/Models/ContainerdInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerdInfo.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerdInfo // (system.ContainerdInfo)

--- a/src/Docker.DotNet/Models/ContainerdNamespaces.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerdNamespaces.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainerdNamespaces // (system.ContainerdNamespaces)

--- a/src/Docker.DotNet/Models/ContainersListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainersListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ContainersListParameters // (main.ContainersListParameters)

--- a/src/Docker.DotNet/Models/ContainersPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainersPruneParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ContainersPruneParameters // (main.ContainersPruneParameters)

--- a/src/Docker.DotNet/Models/ContainersPruneResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainersPruneResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ContainersPruneResponse // (container.PruneReport)

--- a/src/Docker.DotNet/Models/CopyToContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CopyToContainerParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class CopyToContainerParameters // (main.CopyToContainerParameters)

--- a/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CreateContainerParameters // (main.CreateContainerParameters)

--- a/src/Docker.DotNet/Models/CreateContainerResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateContainerResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CreateContainerResponse // (container.CreateResponse)

--- a/src/Docker.DotNet/Models/CreateOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateOptions.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CreateOptions // (network.CreateOptions)

--- a/src/Docker.DotNet/Models/CredentialSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/CredentialSpec.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class CredentialSpec // (swarm.CredentialSpec)

--- a/src/Docker.DotNet/Models/DNSConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/DNSConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DNSConfig // (swarm.DNSConfig)

--- a/src/Docker.DotNet/Models/DefaultNetworkSettings.Generated.cs
+++ b/src/Docker.DotNet/Models/DefaultNetworkSettings.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DefaultNetworkSettings // (container.DefaultNetworkSettings)

--- a/src/Docker.DotNet/Models/Descriptor.Generated.cs
+++ b/src/Docker.DotNet/Models/Descriptor.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Descriptor // (v1.Descriptor)

--- a/src/Docker.DotNet/Models/DeviceMapping.Generated.cs
+++ b/src/Docker.DotNet/Models/DeviceMapping.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DeviceMapping // (container.DeviceMapping)

--- a/src/Docker.DotNet/Models/DeviceRequest.Generated.cs
+++ b/src/Docker.DotNet/Models/DeviceRequest.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DeviceRequest // (container.DeviceRequest)

--- a/src/Docker.DotNet/Models/DiscreteGenericResource.Generated.cs
+++ b/src/Docker.DotNet/Models/DiscreteGenericResource.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DiscreteGenericResource // (swarm.DiscreteGenericResource)

--- a/src/Docker.DotNet/Models/DispatcherConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/DispatcherConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DispatcherConfig // (swarm.DispatcherConfig)

--- a/src/Docker.DotNet/Models/Driver.Generated.cs
+++ b/src/Docker.DotNet/Models/Driver.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Driver // (mount.Driver)

--- a/src/Docker.DotNet/Models/DriverData.Generated.cs
+++ b/src/Docker.DotNet/Models/DriverData.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class DriverData // (storage.DriverData)

--- a/src/Docker.DotNet/Models/EncryptionConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/EncryptionConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EncryptionConfig // (swarm.EncryptionConfig)

--- a/src/Docker.DotNet/Models/Endpoint.Generated.cs
+++ b/src/Docker.DotNet/Models/Endpoint.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Endpoint // (swarm.Endpoint)

--- a/src/Docker.DotNet/Models/EndpointIPAMConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/EndpointIPAMConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EndpointIPAMConfig // (network.EndpointIPAMConfig)

--- a/src/Docker.DotNet/Models/EndpointResource.Generated.cs
+++ b/src/Docker.DotNet/Models/EndpointResource.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EndpointResource // (network.EndpointResource)

--- a/src/Docker.DotNet/Models/EndpointSettings.Generated.cs
+++ b/src/Docker.DotNet/Models/EndpointSettings.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EndpointSettings // (network.EndpointSettings)

--- a/src/Docker.DotNet/Models/EndpointSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/EndpointSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EndpointSpec // (swarm.EndpointSpec)

--- a/src/Docker.DotNet/Models/EndpointVirtualIP.Generated.cs
+++ b/src/Docker.DotNet/Models/EndpointVirtualIP.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EndpointVirtualIP // (swarm.EndpointVirtualIP)

--- a/src/Docker.DotNet/Models/EngineDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/EngineDescription.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class EngineDescription // (swarm.EngineDescription)

--- a/src/Docker.DotNet/Models/ExternalCA.Generated.cs
+++ b/src/Docker.DotNet/Models/ExternalCA.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ExternalCA // (swarm.ExternalCA)

--- a/src/Docker.DotNet/Models/FirewallInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/FirewallInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class FirewallInfo // (system.FirewallInfo)

--- a/src/Docker.DotNet/Models/GenericResource.Generated.cs
+++ b/src/Docker.DotNet/Models/GenericResource.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class GenericResource // (swarm.GenericResource)

--- a/src/Docker.DotNet/Models/GlobalJob.Generated.cs
+++ b/src/Docker.DotNet/Models/GlobalJob.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class GlobalJob // (swarm.GlobalJob)

--- a/src/Docker.DotNet/Models/GlobalService.Generated.cs
+++ b/src/Docker.DotNet/Models/GlobalService.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class GlobalService // (swarm.GlobalService)

--- a/src/Docker.DotNet/Models/Health.Generated.cs
+++ b/src/Docker.DotNet/Models/Health.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Health // (container.Health)

--- a/src/Docker.DotNet/Models/HealthcheckConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/HealthcheckConfig.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class HealthcheckConfig // (v1.HealthcheckConfig)

--- a/src/Docker.DotNet/Models/HealthcheckResult.Generated.cs
+++ b/src/Docker.DotNet/Models/HealthcheckResult.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class HealthcheckResult // (container.HealthcheckResult)

--- a/src/Docker.DotNet/Models/HostConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/HostConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class HostConfig // (container.HostConfig)

--- a/src/Docker.DotNet/Models/IPAM.Generated.cs
+++ b/src/Docker.DotNet/Models/IPAM.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class IPAM // (network.IPAM)

--- a/src/Docker.DotNet/Models/IPAMConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/IPAMConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class IPAMConfig // (network.IPAMConfig)

--- a/src/Docker.DotNet/Models/IPAMOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/IPAMOptions.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class IPAMOptions // (swarm.IPAMOptions)

--- a/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageBuildParameters // (main.ImageBuildParameters)

--- a/src/Docker.DotNet/Models/ImageBuildResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageBuildResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageBuildResponse // (types.ImageBuildResponse)

--- a/src/Docker.DotNet/Models/ImageDeleteParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageDeleteParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ImageDeleteParameters // (main.ImageDeleteParameters)

--- a/src/Docker.DotNet/Models/ImageDeleteResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageDeleteResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageDeleteResponse // (image.DeleteResponse)

--- a/src/Docker.DotNet/Models/ImageHistoryResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageHistoryResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageHistoryResponse // (image.HistoryResponseItem)

--- a/src/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageInspectResponse // (image.InspectResponse)

--- a/src/Docker.DotNet/Models/ImageLoadParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageLoadParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ImageLoadParameters // (main.ImageLoadParameters)

--- a/src/Docker.DotNet/Models/ImageOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageOptions.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageOptions // (mount.ImageOptions)

--- a/src/Docker.DotNet/Models/ImageProperties.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageProperties.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageProperties // (image.ImageProperties)

--- a/src/Docker.DotNet/Models/ImagePropertiesSize.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagePropertiesSize.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagePropertiesSize // (image.ImageProperties.Size)

--- a/src/Docker.DotNet/Models/ImagePushParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagePushParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagePushParameters // (main.ImagePushParameters)

--- a/src/Docker.DotNet/Models/ImageSearchResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageSearchResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImageSearchResponse // (registry.SearchResult)

--- a/src/Docker.DotNet/Models/ImageTagParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageTagParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ImageTagParameters // (main.ImageTagParameters)

--- a/src/Docker.DotNet/Models/ImagesCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesCreateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesCreateParameters // (main.ImagesCreateParameters)

--- a/src/Docker.DotNet/Models/ImagesListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesListParameters // (main.ImagesListParameters)

--- a/src/Docker.DotNet/Models/ImagesListResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesListResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesListResponse // (image.Summary)

--- a/src/Docker.DotNet/Models/ImagesLoadResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesLoadResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesLoadResponse // (image.LoadResponse)

--- a/src/Docker.DotNet/Models/ImagesPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesPruneParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesPruneParameters // (main.ImagesPruneParameters)

--- a/src/Docker.DotNet/Models/ImagesPruneResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesPruneResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesPruneResponse // (image.PruneReport)

--- a/src/Docker.DotNet/Models/ImagesSearchParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesSearchParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ImagesSearchParameters // (main.ImagesSearchParameters)

--- a/src/Docker.DotNet/Models/IndexInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/IndexInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class IndexInfo // (registry.IndexInfo)

--- a/src/Docker.DotNet/Models/Info.Generated.cs
+++ b/src/Docker.DotNet/Models/Info.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Info // (swarm.Info)

--- a/src/Docker.DotNet/Models/JSONError.Generated.cs
+++ b/src/Docker.DotNet/Models/JSONError.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class JSONError // (jsonmessage.JSONError)

--- a/src/Docker.DotNet/Models/JSONMessage.Generated.cs
+++ b/src/Docker.DotNet/Models/JSONMessage.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class JSONMessage // (jsonmessage.JSONMessage)

--- a/src/Docker.DotNet/Models/JSONProgress.Generated.cs
+++ b/src/Docker.DotNet/Models/JSONProgress.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class JSONProgress // (jsonmessage.JSONProgress)

--- a/src/Docker.DotNet/Models/JobStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/JobStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class JobStatus // (swarm.JobStatus)

--- a/src/Docker.DotNet/Models/JoinTokens.Generated.cs
+++ b/src/Docker.DotNet/Models/JoinTokens.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class JoinTokens // (swarm.JoinTokens)

--- a/src/Docker.DotNet/Models/LogConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/LogConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class LogConfig // (container.LogConfig)

--- a/src/Docker.DotNet/Models/ManagerStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/ManagerStatus.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ManagerStatus // (swarm.ManagerStatus)

--- a/src/Docker.DotNet/Models/ManifestSummary.Generated.cs
+++ b/src/Docker.DotNet/Models/ManifestSummary.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ManifestSummary // (image.ManifestSummary)

--- a/src/Docker.DotNet/Models/ManifestSummarySize.Generated.cs
+++ b/src/Docker.DotNet/Models/ManifestSummarySize.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ManifestSummarySize // (image.ManifestSummary.Size)

--- a/src/Docker.DotNet/Models/MemoryStats.Generated.cs
+++ b/src/Docker.DotNet/Models/MemoryStats.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class MemoryStats // (container.MemoryStats)

--- a/src/Docker.DotNet/Models/Message.Generated.cs
+++ b/src/Docker.DotNet/Models/Message.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Message // (events.Message)

--- a/src/Docker.DotNet/Models/Meta.Generated.cs
+++ b/src/Docker.DotNet/Models/Meta.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Meta // (swarm.Meta)

--- a/src/Docker.DotNet/Models/Metadata.Generated.cs
+++ b/src/Docker.DotNet/Models/Metadata.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Metadata // (image.Metadata)

--- a/src/Docker.DotNet/Models/Mount.Generated.cs
+++ b/src/Docker.DotNet/Models/Mount.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Mount // (mount.Mount)

--- a/src/Docker.DotNet/Models/MountPoint.Generated.cs
+++ b/src/Docker.DotNet/Models/MountPoint.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class MountPoint // (container.MountPoint)

--- a/src/Docker.DotNet/Models/NamedGenericResource.Generated.cs
+++ b/src/Docker.DotNet/Models/NamedGenericResource.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NamedGenericResource // (swarm.NamedGenericResource)

--- a/src/Docker.DotNet/Models/Network.Generated.cs
+++ b/src/Docker.DotNet/Models/Network.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Network // (swarm.Network)

--- a/src/Docker.DotNet/Models/NetworkAddressPool.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkAddressPool.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkAddressPool // (system.NetworkAddressPool)

--- a/src/Docker.DotNet/Models/NetworkAttachment.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkAttachment.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkAttachment // (swarm.NetworkAttachment)

--- a/src/Docker.DotNet/Models/NetworkAttachmentConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkAttachmentConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkAttachmentConfig // (swarm.NetworkAttachmentConfig)

--- a/src/Docker.DotNet/Models/NetworkAttachmentSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkAttachmentSpec.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkAttachmentSpec // (swarm.NetworkAttachmentSpec)

--- a/src/Docker.DotNet/Models/NetworkConnectParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkConnectParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkConnectParameters // (network.ConnectOptions)

--- a/src/Docker.DotNet/Models/NetworkDisconnectParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkDisconnectParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkDisconnectParameters // (network.DisconnectOptions)

--- a/src/Docker.DotNet/Models/NetworkResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkResponse // (network.Inspect)

--- a/src/Docker.DotNet/Models/NetworkSettings.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkSettings.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkSettings // (container.NetworkSettings)

--- a/src/Docker.DotNet/Models/NetworkSettingsBase.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkSettingsBase.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkSettingsBase // (container.NetworkSettingsBase)

--- a/src/Docker.DotNet/Models/NetworkSettingsSummary.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkSettingsSummary.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkSettingsSummary // (container.NetworkSettingsSummary)

--- a/src/Docker.DotNet/Models/NetworkSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkSpec // (swarm.NetworkSpec)

--- a/src/Docker.DotNet/Models/NetworkStats.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkStats.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkStats // (container.NetworkStats)

--- a/src/Docker.DotNet/Models/NetworkTask.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkTask.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkTask // (network.Task)

--- a/src/Docker.DotNet/Models/NetworkingConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworkingConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworkingConfig // (network.NetworkingConfig)

--- a/src/Docker.DotNet/Models/NetworksCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksCreateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworksCreateParameters // (network.CreateRequest)

--- a/src/Docker.DotNet/Models/NetworksCreateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksCreateResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworksCreateResponse // (network.CreateResponse)

--- a/src/Docker.DotNet/Models/NetworksDeleteUnusedParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksDeleteUnusedParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class NetworksDeleteUnusedParameters // (main.NetworksDeleteUnusedParameters)

--- a/src/Docker.DotNet/Models/NetworksListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class NetworksListParameters // (main.NetworksListParameters)

--- a/src/Docker.DotNet/Models/NetworksPruneResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksPruneResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NetworksPruneResponse // (network.PruneReport)

--- a/src/Docker.DotNet/Models/NodeCSIInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeCSIInfo.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NodeCSIInfo // (swarm.NodeCSIInfo)

--- a/src/Docker.DotNet/Models/NodeDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeDescription.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NodeDescription // (swarm.NodeDescription)

--- a/src/Docker.DotNet/Models/NodeListResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeListResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NodeListResponse // (swarm.Node)

--- a/src/Docker.DotNet/Models/NodeRemoveParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeRemoveParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class NodeRemoveParameters // (main.NodeRemoveParameters)

--- a/src/Docker.DotNet/Models/NodeStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeStatus.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NodeStatus // (swarm.NodeStatus)

--- a/src/Docker.DotNet/Models/NodeUpdateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NodeUpdateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class NodeUpdateParameters // (swarm.NodeSpec)

--- a/src/Docker.DotNet/Models/OrchestrationConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/OrchestrationConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class OrchestrationConfig // (swarm.OrchestrationConfig)

--- a/src/Docker.DotNet/Models/Peer.Generated.cs
+++ b/src/Docker.DotNet/Models/Peer.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Peer // (swarm.Peer)

--- a/src/Docker.DotNet/Models/PeerInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/PeerInfo.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PeerInfo // (network.PeerInfo)

--- a/src/Docker.DotNet/Models/PidsStats.Generated.cs
+++ b/src/Docker.DotNet/Models/PidsStats.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PidsStats // (container.PidsStats)

--- a/src/Docker.DotNet/Models/Placement.Generated.cs
+++ b/src/Docker.DotNet/Models/Placement.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Placement // (swarm.Placement)

--- a/src/Docker.DotNet/Models/PlacementPreference.Generated.cs
+++ b/src/Docker.DotNet/Models/PlacementPreference.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PlacementPreference // (swarm.PlacementPreference)

--- a/src/Docker.DotNet/Models/Platform.Generated.cs
+++ b/src/Docker.DotNet/Models/Platform.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Platform // (v1.Platform)

--- a/src/Docker.DotNet/Models/Plugin.Generated.cs
+++ b/src/Docker.DotNet/Models/Plugin.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Plugin // (types.Plugin)

--- a/src/Docker.DotNet/Models/PluginConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfig // (types.PluginConfig)

--- a/src/Docker.DotNet/Models/PluginConfigArgs.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigArgs.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigArgs // (types.PluginConfigArgs)

--- a/src/Docker.DotNet/Models/PluginConfigInterface.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigInterface.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigInterface // (types.PluginConfigInterface)

--- a/src/Docker.DotNet/Models/PluginConfigLinux.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigLinux.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigLinux // (types.PluginConfigLinux)

--- a/src/Docker.DotNet/Models/PluginConfigNetwork.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigNetwork.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigNetwork // (types.PluginConfigNetwork)

--- a/src/Docker.DotNet/Models/PluginConfigRootfs.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigRootfs.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigRootfs // (types.PluginConfigRootfs)

--- a/src/Docker.DotNet/Models/PluginConfigUser.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigUser.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigUser // (types.PluginConfigUser)

--- a/src/Docker.DotNet/Models/PluginConfigureParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginConfigureParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginConfigureParameters // (main.PluginConfigureParameters)

--- a/src/Docker.DotNet/Models/PluginCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginCreateParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class PluginCreateParameters // (main.PluginCreateParameters)

--- a/src/Docker.DotNet/Models/PluginDescription.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginDescription.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginDescription // (swarm.PluginDescription)

--- a/src/Docker.DotNet/Models/PluginDevice.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginDevice.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginDevice // (types.PluginDevice)

--- a/src/Docker.DotNet/Models/PluginDisableParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginDisableParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class PluginDisableParameters // (main.PluginDisableParameters)

--- a/src/Docker.DotNet/Models/PluginEnableParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginEnableParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class PluginEnableParameters // (main.PluginEnableParameters)

--- a/src/Docker.DotNet/Models/PluginEnv.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginEnv.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginEnv // (types.PluginEnv)

--- a/src/Docker.DotNet/Models/PluginGetPrivilegeParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginGetPrivilegeParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class PluginGetPrivilegeParameters // (main.PluginGetPrivilegeParameters)

--- a/src/Docker.DotNet/Models/PluginInstallParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginInstallParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginInstallParameters // (main.PluginInstallParameters)

--- a/src/Docker.DotNet/Models/PluginInterfaceType.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginInterfaceType.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginInterfaceType // (types.PluginInterfaceType)

--- a/src/Docker.DotNet/Models/PluginListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class PluginListParameters // (main.PluginListParameters)

--- a/src/Docker.DotNet/Models/PluginMount.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginMount.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginMount // (types.PluginMount)

--- a/src/Docker.DotNet/Models/PluginPrivilege.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginPrivilege.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginPrivilege // (types.PluginPrivilege)

--- a/src/Docker.DotNet/Models/PluginRemoveParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginRemoveParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class PluginRemoveParameters // (main.PluginRemoveParameters)

--- a/src/Docker.DotNet/Models/PluginSettings.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginSettings.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginSettings // (types.PluginSettings)

--- a/src/Docker.DotNet/Models/PluginSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginSpec // (runtime.PluginSpec)

--- a/src/Docker.DotNet/Models/PluginUpgradeParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginUpgradeParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginUpgradeParameters // (main.PluginUpgradeParameters)

--- a/src/Docker.DotNet/Models/PluginsInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginsInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PluginsInfo // (system.PluginsInfo)

--- a/src/Docker.DotNet/Models/Port.Generated.cs
+++ b/src/Docker.DotNet/Models/Port.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Port // (container.Port)

--- a/src/Docker.DotNet/Models/PortBinding.Generated.cs
+++ b/src/Docker.DotNet/Models/PortBinding.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PortBinding // (nat.PortBinding)

--- a/src/Docker.DotNet/Models/PortConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/PortConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PortConfig // (swarm.PortConfig)

--- a/src/Docker.DotNet/Models/PortStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/PortStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PortStatus // (swarm.PortStatus)

--- a/src/Docker.DotNet/Models/Privileges.Generated.cs
+++ b/src/Docker.DotNet/Models/Privileges.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Privileges // (swarm.Privileges)

--- a/src/Docker.DotNet/Models/PublishStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/PublishStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class PublishStatus // (volume.PublishStatus)

--- a/src/Docker.DotNet/Models/RaftConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/RaftConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class RaftConfig // (swarm.RaftConfig)

--- a/src/Docker.DotNet/Models/ReplicatedJob.Generated.cs
+++ b/src/Docker.DotNet/Models/ReplicatedJob.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ReplicatedJob // (swarm.ReplicatedJob)

--- a/src/Docker.DotNet/Models/ReplicatedService.Generated.cs
+++ b/src/Docker.DotNet/Models/ReplicatedService.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ReplicatedService // (swarm.ReplicatedService)

--- a/src/Docker.DotNet/Models/ResourceRequirements.Generated.cs
+++ b/src/Docker.DotNet/Models/ResourceRequirements.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ResourceRequirements // (swarm.ResourceRequirements)

--- a/src/Docker.DotNet/Models/Resources.Generated.cs
+++ b/src/Docker.DotNet/Models/Resources.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Resources // (container.Resources)

--- a/src/Docker.DotNet/Models/RestartPolicy.Generated.cs
+++ b/src/Docker.DotNet/Models/RestartPolicy.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class RestartPolicy // (container.RestartPolicy)

--- a/src/Docker.DotNet/Models/RootFS.Generated.cs
+++ b/src/Docker.DotNet/Models/RootFS.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class RootFS // (image.RootFS)

--- a/src/Docker.DotNet/Models/Runtime.Generated.cs
+++ b/src/Docker.DotNet/Models/Runtime.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Runtime // (system.Runtime)

--- a/src/Docker.DotNet/Models/RuntimePluginPrivilege.Generated.cs
+++ b/src/Docker.DotNet/Models/RuntimePluginPrivilege.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class RuntimePluginPrivilege // (runtime.PluginPrivilege)

--- a/src/Docker.DotNet/Models/RuntimeWithStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/RuntimeWithStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class RuntimeWithStatus // (system.RuntimeWithStatus)

--- a/src/Docker.DotNet/Models/SELinuxContext.Generated.cs
+++ b/src/Docker.DotNet/Models/SELinuxContext.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SELinuxContext // (swarm.SELinuxContext)

--- a/src/Docker.DotNet/Models/SeccompOpts.Generated.cs
+++ b/src/Docker.DotNet/Models/SeccompOpts.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SeccompOpts // (swarm.SeccompOpts)

--- a/src/Docker.DotNet/Models/Secret.Generated.cs
+++ b/src/Docker.DotNet/Models/Secret.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Secret // (swarm.Secret)

--- a/src/Docker.DotNet/Models/SecretCreateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SecretCreateResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SecretCreateResponse // (main.SecretCreateResponse)

--- a/src/Docker.DotNet/Models/SecretReference.Generated.cs
+++ b/src/Docker.DotNet/Models/SecretReference.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SecretReference // (swarm.SecretReference)

--- a/src/Docker.DotNet/Models/SecretReferenceFileTarget.Generated.cs
+++ b/src/Docker.DotNet/Models/SecretReferenceFileTarget.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SecretReferenceFileTarget // (swarm.SecretReferenceFileTarget)

--- a/src/Docker.DotNet/Models/SecretSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/SecretSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SecretSpec // (swarm.SecretSpec)

--- a/src/Docker.DotNet/Models/ServiceConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceConfig // (registry.ServiceConfig)

--- a/src/Docker.DotNet/Models/ServiceCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceCreateParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceCreateParameters // (main.ServiceCreateParameters)

--- a/src/Docker.DotNet/Models/ServiceCreateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceCreateResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceCreateResponse // (swarm.ServiceCreateResponse)

--- a/src/Docker.DotNet/Models/ServiceInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceInfo // (network.ServiceInfo)

--- a/src/Docker.DotNet/Models/ServiceListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceListParameters // (main.ServiceListParameters)

--- a/src/Docker.DotNet/Models/ServiceLogsParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceLogsParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class ServiceLogsParameters // (main.ServiceLogsParameters)

--- a/src/Docker.DotNet/Models/ServiceMode.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceMode.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceMode // (swarm.ServiceMode)

--- a/src/Docker.DotNet/Models/ServiceSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceSpec // (swarm.ServiceSpec)

--- a/src/Docker.DotNet/Models/ServiceStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceStatus.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceStatus // (swarm.ServiceStatus)

--- a/src/Docker.DotNet/Models/ServiceUpdateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceUpdateParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceUpdateParameters // (main.ServiceUpdateParameters)

--- a/src/Docker.DotNet/Models/ServiceUpdateResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceUpdateResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ServiceUpdateResponse // (swarm.ServiceUpdateResponse)

--- a/src/Docker.DotNet/Models/Spec.Generated.cs
+++ b/src/Docker.DotNet/Models/Spec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Spec // (swarm.Spec)

--- a/src/Docker.DotNet/Models/SpreadOver.Generated.cs
+++ b/src/Docker.DotNet/Models/SpreadOver.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SpreadOver // (swarm.SpreadOver)

--- a/src/Docker.DotNet/Models/State.Generated.cs
+++ b/src/Docker.DotNet/Models/State.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class State // (container.State)

--- a/src/Docker.DotNet/Models/StorageStats.Generated.cs
+++ b/src/Docker.DotNet/Models/StorageStats.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class StorageStats // (container.StorageStats)

--- a/src/Docker.DotNet/Models/SummaryHostConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/SummaryHostConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SummaryHostConfig // (container.Summary.HostConfig)

--- a/src/Docker.DotNet/Models/SwarmConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmConfig // (main.SwarmConfig)

--- a/src/Docker.DotNet/Models/SwarmConfigReference.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmConfigReference.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmConfigReference // (swarm.ConfigReference)

--- a/src/Docker.DotNet/Models/SwarmConfigSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmConfigSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmConfigSpec // (swarm.ConfigSpec)

--- a/src/Docker.DotNet/Models/SwarmCreateConfigParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmCreateConfigParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmCreateConfigParameters // (main.SwarmCreateConfigParameters)

--- a/src/Docker.DotNet/Models/SwarmCreateConfigResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmCreateConfigResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmCreateConfigResponse // (main.SwarmCreateConfigResponse)

--- a/src/Docker.DotNet/Models/SwarmDriver.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmDriver.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmDriver // (swarm.Driver)

--- a/src/Docker.DotNet/Models/SwarmIPAMConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmIPAMConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmIPAMConfig // (swarm.IPAMConfig)

--- a/src/Docker.DotNet/Models/SwarmInitParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmInitParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmInitParameters // (swarm.InitRequest)

--- a/src/Docker.DotNet/Models/SwarmInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmInspectResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmInspectResponse // (swarm.Swarm)

--- a/src/Docker.DotNet/Models/SwarmJoinParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmJoinParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmJoinParameters // (swarm.JoinRequest)

--- a/src/Docker.DotNet/Models/SwarmLeaveParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmLeaveParameters.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class SwarmLeaveParameters // (main.SwarmLeaveParameters)

--- a/src/Docker.DotNet/Models/SwarmLimit.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmLimit.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmLimit // (swarm.Limit)

--- a/src/Docker.DotNet/Models/SwarmPlatform.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmPlatform.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmPlatform // (swarm.Platform)

--- a/src/Docker.DotNet/Models/SwarmResources.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmResources.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmResources // (swarm.Resources)

--- a/src/Docker.DotNet/Models/SwarmRestartPolicy.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmRestartPolicy.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmRestartPolicy // (swarm.RestartPolicy)

--- a/src/Docker.DotNet/Models/SwarmService.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmService.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmService // (swarm.Service)

--- a/src/Docker.DotNet/Models/SwarmUnlockParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmUnlockParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmUnlockParameters // (main.SwarmUnlockParameters)

--- a/src/Docker.DotNet/Models/SwarmUnlockResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmUnlockResponse.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmUnlockResponse // (main.SwarmUnlockResponse)

--- a/src/Docker.DotNet/Models/SwarmUpdateConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmUpdateConfig.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmUpdateConfig // (swarm.UpdateConfig)

--- a/src/Docker.DotNet/Models/SwarmUpdateConfigParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmUpdateConfigParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmUpdateConfigParameters // (main.SwarmUpdateConfigParameters)

--- a/src/Docker.DotNet/Models/SwarmUpdateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/SwarmUpdateParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SwarmUpdateParameters // (main.SwarmUpdateParameters)

--- a/src/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class SystemInfoResponse // (system.Info)

--- a/src/Docker.DotNet/Models/TLSInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/TLSInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TLSInfo // (swarm.TLSInfo)

--- a/src/Docker.DotNet/Models/TaskDefaults.Generated.cs
+++ b/src/Docker.DotNet/Models/TaskDefaults.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TaskDefaults // (swarm.TaskDefaults)

--- a/src/Docker.DotNet/Models/TaskResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/TaskResponse.Generated.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TaskResponse // (swarm.Task)

--- a/src/Docker.DotNet/Models/TaskSpec.Generated.cs
+++ b/src/Docker.DotNet/Models/TaskSpec.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TaskSpec // (swarm.TaskSpec)

--- a/src/Docker.DotNet/Models/TaskStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/TaskStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TaskStatus // (swarm.TaskStatus)

--- a/src/Docker.DotNet/Models/TasksListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/TasksListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class TasksListParameters // (main.TasksListParameters)

--- a/src/Docker.DotNet/Models/ThrottleDevice.Generated.cs
+++ b/src/Docker.DotNet/Models/ThrottleDevice.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ThrottleDevice // (blkiodev.ThrottleDevice)

--- a/src/Docker.DotNet/Models/ThrottlingData.Generated.cs
+++ b/src/Docker.DotNet/Models/ThrottlingData.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class ThrottlingData // (container.ThrottlingData)

--- a/src/Docker.DotNet/Models/TmpfsOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/TmpfsOptions.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TmpfsOptions // (mount.TmpfsOptions)

--- a/src/Docker.DotNet/Models/Topology.Generated.cs
+++ b/src/Docker.DotNet/Models/Topology.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Topology // (swarm.Topology)

--- a/src/Docker.DotNet/Models/TopologyRequirement.Generated.cs
+++ b/src/Docker.DotNet/Models/TopologyRequirement.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TopologyRequirement // (volume.TopologyRequirement)

--- a/src/Docker.DotNet/Models/TypeBlock.Generated.cs
+++ b/src/Docker.DotNet/Models/TypeBlock.Generated.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models
 {
     public class TypeBlock // (volume.TypeBlock)

--- a/src/Docker.DotNet/Models/TypeMount.Generated.cs
+++ b/src/Docker.DotNet/Models/TypeMount.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class TypeMount // (volume.TypeMount)

--- a/src/Docker.DotNet/Models/Ulimit.Generated.cs
+++ b/src/Docker.DotNet/Models/Ulimit.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Ulimit // (units.Ulimit)

--- a/src/Docker.DotNet/Models/UpdateConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/UpdateConfig.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class UpdateConfig // (container.UpdateConfig)

--- a/src/Docker.DotNet/Models/UpdateStatus.Generated.cs
+++ b/src/Docker.DotNet/Models/UpdateStatus.Generated.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class UpdateStatus // (swarm.UpdateStatus)

--- a/src/Docker.DotNet/Models/UsageData.Generated.cs
+++ b/src/Docker.DotNet/Models/UsageData.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class UsageData // (volume.UsageData)

--- a/src/Docker.DotNet/Models/Version.Generated.cs
+++ b/src/Docker.DotNet/Models/Version.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class Version // (swarm.Version)

--- a/src/Docker.DotNet/Models/VersionPlatform.Generated.cs
+++ b/src/Docker.DotNet/Models/VersionPlatform.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VersionPlatform // (types.Version.Platform)

--- a/src/Docker.DotNet/Models/VersionResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/VersionResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VersionResponse // (types.Version)

--- a/src/Docker.DotNet/Models/VolumeAccessMode.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeAccessMode.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeAccessMode // (volume.AccessMode)

--- a/src/Docker.DotNet/Models/VolumeAttachment.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeAttachment.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeAttachment // (swarm.VolumeAttachment)

--- a/src/Docker.DotNet/Models/VolumeInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeInfo.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeInfo // (volume.Info)

--- a/src/Docker.DotNet/Models/VolumeOptions.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeOptions.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeOptions // (mount.VolumeOptions)

--- a/src/Docker.DotNet/Models/VolumeResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeResponse // (main.VolumeResponse)

--- a/src/Docker.DotNet/Models/VolumeSecret.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeSecret.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeSecret // (volume.Secret)

--- a/src/Docker.DotNet/Models/VolumeTopology.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumeTopology.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumeTopology // (volume.Topology)

--- a/src/Docker.DotNet/Models/VolumesCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesCreateParameters.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumesCreateParameters // (main.VolumesCreateParameters)

--- a/src/Docker.DotNet/Models/VolumesListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesListParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class VolumesListParameters // (main.VolumesListParameters)

--- a/src/Docker.DotNet/Models/VolumesListResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesListResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumesListResponse // (main.VolumesListResponse)

--- a/src/Docker.DotNet/Models/VolumesPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesPruneParameters.Generated.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Docker.DotNet.Models
 {
     public class VolumesPruneParameters // (main.VolumesPruneParameters)

--- a/src/Docker.DotNet/Models/VolumesPruneResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesPruneResponse.Generated.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class VolumesPruneResponse // (volume.PruneReport)

--- a/src/Docker.DotNet/Models/WaitExitError.Generated.cs
+++ b/src/Docker.DotNet/Models/WaitExitError.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class WaitExitError // (container.WaitExitError)

--- a/src/Docker.DotNet/Models/WeightDevice.Generated.cs
+++ b/src/Docker.DotNet/Models/WeightDevice.Generated.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Docker.DotNet.Models
 {
     public class WeightDevice // (blkiodev.WeightDevice)


### PR DESCRIPTION
The PR removes the unnecessary global usings from the generated model classes. Related to #39.