### PR TITLE
feat: Update specgen configuration to Docker Engine API 28.3.3

### DIFF
--- a/src/Docker.DotNet/Models/CommitContainerChangesParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CommitContainerChangesParameters.Generated.cs
@@ -6,7 +6,7 @@ namespace Docker.DotNet.Models
         {
         }
 
-        public CommitContainerChangesParameters(Config Config)
+        public CommitContainerChangesParameters(ContainerConfig Config)
         {
             if (Config != null)
             {

--- a/src/Docker.DotNet/Models/ContainerConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerConfig.Generated.cs
@@ -1,6 +1,6 @@
 namespace Docker.DotNet.Models
 {
-    public class Config // (container.Config)
+    public class ContainerConfig // (container.Config)
     {
         [JsonPropertyName("Hostname")]
         public string Hostname { get; set; }

--- a/src/Docker.DotNet/Models/ContainerExecCreateParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerExecCreateParameters.Generated.cs
@@ -23,9 +23,6 @@ namespace Docker.DotNet.Models
         [JsonPropertyName("AttachStdout")]
         public bool AttachStdout { get; set; }
 
-        [JsonPropertyName("Detach")]
-        public bool Detach { get; set; }
-
         [JsonPropertyName("DetachKeys")]
         public string DetachKeys { get; set; }
 
@@ -37,5 +34,8 @@ namespace Docker.DotNet.Models
 
         [JsonPropertyName("Cmd")]
         public IList<string> Cmd { get; set; }
+
+        [JsonPropertyName("Detach")]
+        public bool Detach { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
@@ -105,7 +105,7 @@ namespace Docker.DotNet.Models
         public IList<MountPoint> Mounts { get; set; }
 
         [JsonPropertyName("Config")]
-        public Config Config { get; set; }
+        public ContainerConfig Config { get; set; }
 
         [JsonPropertyName("NetworkSettings")]
         public NetworkSettings NetworkSettings { get; set; }

--- a/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/CreateContainerParameters.Generated.cs
@@ -6,7 +6,7 @@ namespace Docker.DotNet.Models
         {
         }
 
-        public CreateContainerParameters(Config Config)
+        public CreateContainerParameters(ContainerConfig Config)
         {
             if (Config != null)
             {

--- a/src/Docker.DotNet/Models/DeviceInfo.Generated.cs
+++ b/src/Docker.DotNet/Models/DeviceInfo.Generated.cs
@@ -1,0 +1,11 @@
+namespace Docker.DotNet.Models
+{
+    public class DeviceInfo // (system.DeviceInfo)
+    {
+        [JsonPropertyName("Source")]
+        public string Source { get; set; }
+
+        [JsonPropertyName("ID")]
+        public string ID { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/DockerOCIImageConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/DockerOCIImageConfig.Generated.cs
@@ -1,0 +1,68 @@
+namespace Docker.DotNet.Models
+{
+    public class DockerOCIImageConfig // (v1.DockerOCIImageConfig)
+    {
+        public DockerOCIImageConfig()
+        {
+        }
+
+        public DockerOCIImageConfig(ImageConfig ImageConfig, DockerOCIImageConfigExt DockerOCIImageConfigExt)
+        {
+            if (ImageConfig != null)
+            {
+                this.User = ImageConfig.User;
+                this.ExposedPorts = ImageConfig.ExposedPorts;
+                this.Env = ImageConfig.Env;
+                this.Entrypoint = ImageConfig.Entrypoint;
+                this.Cmd = ImageConfig.Cmd;
+                this.Volumes = ImageConfig.Volumes;
+                this.WorkingDir = ImageConfig.WorkingDir;
+                this.Labels = ImageConfig.Labels;
+                this.StopSignal = ImageConfig.StopSignal;
+            }
+
+            if (DockerOCIImageConfigExt != null)
+            {
+                this.Healthcheck = DockerOCIImageConfigExt.Healthcheck;
+                this.OnBuild = DockerOCIImageConfigExt.OnBuild;
+                this.Shell = DockerOCIImageConfigExt.Shell;
+            }
+        }
+
+        [JsonPropertyName("User")]
+        public string User { get; set; }
+
+        [JsonPropertyName("ExposedPorts")]
+        public IDictionary<string, EmptyStruct> ExposedPorts { get; set; }
+
+        [JsonPropertyName("Env")]
+        public IList<string> Env { get; set; }
+
+        [JsonPropertyName("Entrypoint")]
+        public IList<string> Entrypoint { get; set; }
+
+        [JsonPropertyName("Cmd")]
+        public IList<string> Cmd { get; set; }
+
+        [JsonPropertyName("Volumes")]
+        public IDictionary<string, EmptyStruct> Volumes { get; set; }
+
+        [JsonPropertyName("WorkingDir")]
+        public string WorkingDir { get; set; }
+
+        [JsonPropertyName("Labels")]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [JsonPropertyName("StopSignal")]
+        public string StopSignal { get; set; }
+
+        [JsonPropertyName("Healthcheck")]
+        public HealthcheckConfig Healthcheck { get; set; }
+
+        [JsonPropertyName("OnBuild")]
+        public IList<string> OnBuild { get; set; }
+
+        [JsonPropertyName("Shell")]
+        public IList<string> Shell { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/DockerOCIImageConfigExt.Generated.cs
+++ b/src/Docker.DotNet/Models/DockerOCIImageConfigExt.Generated.cs
@@ -1,0 +1,14 @@
+namespace Docker.DotNet.Models
+{
+    public class DockerOCIImageConfigExt // (v1.DockerOCIImageConfigExt)
+    {
+        [JsonPropertyName("Healthcheck")]
+        public HealthcheckConfig Healthcheck { get; set; }
+
+        [JsonPropertyName("OnBuild")]
+        public IList<string> OnBuild { get; set; }
+
+        [JsonPropertyName("Shell")]
+        public IList<string> Shell { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/ImageBuildResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageBuildResponse.Generated.cs
@@ -1,6 +1,6 @@
 namespace Docker.DotNet.Models
 {
-    public class ImageBuildResponse // (types.ImageBuildResponse)
+    public class ImageBuildResponse // (build.ImageBuildResponse)
     {
         [JsonPropertyName("Body")]
         public object Body { get; set; }

--- a/src/Docker.DotNet/Models/ImageConfig.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageConfig.Generated.cs
@@ -1,0 +1,32 @@
+namespace Docker.DotNet.Models
+{
+    public class ImageConfig // (v1.ImageConfig)
+    {
+        [JsonPropertyName("User")]
+        public string User { get; set; }
+
+        [JsonPropertyName("ExposedPorts")]
+        public IDictionary<string, EmptyStruct> ExposedPorts { get; set; }
+
+        [JsonPropertyName("Env")]
+        public IList<string> Env { get; set; }
+
+        [JsonPropertyName("Entrypoint")]
+        public IList<string> Entrypoint { get; set; }
+
+        [JsonPropertyName("Cmd")]
+        public IList<string> Cmd { get; set; }
+
+        [JsonPropertyName("Volumes")]
+        public IDictionary<string, EmptyStruct> Volumes { get; set; }
+
+        [JsonPropertyName("WorkingDir")]
+        public string WorkingDir { get; set; }
+
+        [JsonPropertyName("Labels")]
+        public IDictionary<string, string> Labels { get; set; }
+
+        [JsonPropertyName("StopSignal")]
+        public string StopSignal { get; set; }
+    }
+}

--- a/src/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageInspectResponse.Generated.cs
@@ -24,7 +24,7 @@ namespace Docker.DotNet.Models
         public string Container { get; set; }
 
         [JsonPropertyName("ContainerConfig")]
-        public Config ContainerConfig { get; set; }
+        public ContainerConfig ContainerConfig { get; set; }
 
         [JsonPropertyName("DockerVersion")]
         public string DockerVersion { get; set; }
@@ -33,7 +33,7 @@ namespace Docker.DotNet.Models
         public string Author { get; set; }
 
         [JsonPropertyName("Config")]
-        public Config Config { get; set; }
+        public DockerOCIImageConfig Config { get; set; }
 
         [JsonPropertyName("Architecture")]
         public string Architecture { get; set; }

--- a/src/Docker.DotNet/Models/RestartPolicyKind.cs
+++ b/src/Docker.DotNet/Models/RestartPolicyKind.cs
@@ -1,4 +1,3 @@
-
 namespace Docker.DotNet.Models;
 
 public enum RestartPolicyKind

--- a/src/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
+++ b/src/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
@@ -62,12 +62,6 @@ namespace Docker.DotNet.Models
         [JsonPropertyName("IPv4Forwarding")]
         public bool IPv4Forwarding { get; set; }
 
-        [JsonPropertyName("BridgeNfIptables")]
-        public bool BridgeNfIptables { get; set; }
-
-        [JsonPropertyName("BridgeNfIp6tables")]
-        public bool BridgeNfIP6tables { get; set; }
-
         [JsonPropertyName("Debug")]
         public bool Debug { get; set; }
 
@@ -190,6 +184,9 @@ namespace Docker.DotNet.Models
 
         [JsonPropertyName("CDISpecDirs")]
         public IList<string> CDISpecDirs { get; set; }
+
+        [JsonPropertyName("DiscoveredDevices")]
+        public IList<DeviceInfo> DiscoveredDevices { get; set; }
 
         [JsonPropertyName("Containerd")]
         public ContainerdInfo Containerd { get; set; }

--- a/tools/specgen/go.mod
+++ b/tools/specgen/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v28.1.1+incompatible
+	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect

--- a/tools/specgen/go.sum
+++ b/tools/specgen/go.sum
@@ -6,8 +6,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v28.1.1+incompatible h1:49M11BFLsVO1gxY9UX9p/zwkE/rswggs8AdFmXQw51I=
-github.com/docker/docker v28.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
+github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/image"
@@ -30,44 +31,45 @@ func typeToKey(t reflect.Type) string {
 
 var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(container.Config{})): {
+		Name: "ContainerConfig",
 		Properties: []CSProperty{
-			CSProperty{
+			{
 				Name:       "StopTimeout",
 				Type:       CSType{"System", "TimeSpan", true},
-				Attributes: []CSAttribute{CSAttribute{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanSecondsConverter)"}}}},
+				Attributes: []CSAttribute{{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanSecondsConverter)"}}}},
 			},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.CreateResponse{})): {Name: "CreateContainerResponse"},
 	typeToKey(reflect.TypeOf(container.HealthConfig{})): {
 		Properties: []CSProperty{
-			CSProperty{
+			{
 				Name:       "Interval",
 				Type:       CSType{"System", "TimeSpan", true},
-				Attributes: []CSAttribute{CSAttribute{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanNanosecondsConverter)"}}}},
+				Attributes: []CSAttribute{{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanNanosecondsConverter)"}}}},
 			},
-			CSProperty{
+			{
 				Name:       "Timeout",
 				Type:       CSType{"System", "TimeSpan", true},
-				Attributes: []CSAttribute{CSAttribute{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanNanosecondsConverter)"}}}},
+				Attributes: []CSAttribute{{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanNanosecondsConverter)"}}}},
 			},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.RestartPolicy{})): {
-		Properties: []CSProperty{CSProperty{Name: "Name", Type: CSType{"", "RestartPolicyKind", false}}},
+		Properties: []CSProperty{{Name: "Name", Type: CSType{"", "RestartPolicyKind", false}}},
 	},
 	typeToKey(reflect.TypeOf(jsonmessage.JSONMessage{})): {
 		Properties: []CSProperty{
-			CSProperty{Name: "Time", Type: CSType{"System", "DateTime", false}},
-			CSProperty{Name: "Aux", Type: CSType{"", "ObjectExtensionData", false}},
+			{Name: "Time", Type: CSType{"System", "DateTime", false}},
+			{Name: "Aux", Type: CSType{"", "ObjectExtensionData", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(CreateContainerParameters{})): {
 		Properties: []CSProperty{
-			CSProperty{
+			{
 				Name:       "StopTimeout",
 				Type:       CSType{"System", "TimeSpan", true},
-				Attributes: []CSAttribute{CSAttribute{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanSecondsConverter)"}}}},
+				Attributes: []CSAttribute{{Type: CSType{"System.Text.Json.Serialization", "JsonConverter", false}, Arguments: []CSArgument{{Value: "typeof(TimeSpanSecondsConverter)"}}}},
 			},
 		},
 	},
@@ -95,12 +97,12 @@ var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(swarm.Task{})): {
 		Name: "TaskResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "DesiredState", Type: CSType{"", "TaskState", false}},
+			{Name: "DesiredState", Type: CSType{"", "TaskState", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(swarm.TaskStatus{})): {
 		Properties: []CSProperty{
-			CSProperty{Name: "State", Type: CSType{"", "TaskState", false}},
+			{Name: "State", Type: CSType{"", "TaskState", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(swarm.UpdateConfig{})):    {Name: "SwarmUpdateConfig"},
@@ -108,20 +110,20 @@ var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(container.Summary{})): {
 		Name: "ContainerListResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "Created", Type: CSType{"System", "DateTime", false}},
+			{Name: "Created", Type: CSType{"System", "DateTime", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.FilesystemChange{})): {
 		Name: "ContainerFileSystemChangeResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "Kind", Type: CSType{"", "FileSystemChangeKind", false}},
+			{Name: "Kind", Type: CSType{"", "FileSystemChangeKind", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.ExecInspect{})):     {Name: "ContainerExecInspectResponse"},
 	typeToKey(reflect.TypeOf(container.InspectResponse{})): {Name: "ContainerInspectResponse"},
 	typeToKey(reflect.TypeOf(container.ContainerJSONBase{})): {
 		Properties: []CSProperty{
-			CSProperty{Name: "Created", Type: CSType{"System", "DateTime", false}},
+			{Name: "Created", Type: CSType{"System", "DateTime", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.PathStat{})):    {Name: "ContainerPathStatResponse"},
@@ -131,13 +133,13 @@ var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(image.HistoryResponseItem{})): {
 		Name: "ImageHistoryResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "Created", Type: CSType{"System", "DateTime", false}},
+			{Name: "Created", Type: CSType{"System", "DateTime", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(image.InspectResponse{})): {
 		Name: "ImageInspectResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "Created", Type: CSType{"System", "DateTime", false}},
+			{Name: "Created", Type: CSType{"System", "DateTime", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(image.LoadResponse{})): {Name: "ImagesLoadResponse"},
@@ -145,7 +147,7 @@ var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(image.Summary{})): {
 		Name: "ImagesListResponse",
 		Properties: []CSProperty{
-			CSProperty{Name: "Created", Type: CSType{"System", "DateTime", false}},
+			{Name: "Created", Type: CSType{"System", "DateTime", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(system.Info{})):               {Name: "SystemInfoResponse"},
@@ -158,7 +160,7 @@ var typesToDisambiguate = map[string]*CSModelType{
 	typeToKey(reflect.TypeOf(types.PluginConfigInterface{})): {
 		Name: "PluginConfigInterface",
 		Properties: []CSProperty{
-			CSProperty{Name: "Types", Type: CSType{"System.Collections.Generic", "IList<string>", false}},
+			{Name: "Types", Type: CSType{"System.Collections.Generic", "IList<string>", false}},
 		},
 	},
 	typeToKey(reflect.TypeOf(container.StatsResponse{})): {Name: "ContainerStatsResponse"},
@@ -175,7 +177,7 @@ var dockerTypesToReflect = []reflect.Type{
 
 	// POST /build
 	reflect.TypeOf(ImageBuildParameters{}),
-	reflect.TypeOf(types.ImageBuildResponse{}),
+	reflect.TypeOf(build.ImageBuildResponse{}),
 
 	// POST /commit
 	reflect.TypeOf(CommitContainerChangesParameters{}),

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.128.5",
+  "version": "3.129.5",
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
The PR updates the Docker Engine API to the latest version (used in Docker Desktop). The previously used version is outdated. In addition to the version update, the PR also removes various warnings.