### PR TITLE
feat: Automatically update model classes using scripts

### DIFF
--- a/tools/specgen/README.md
+++ b/tools/specgen/README.md
@@ -6,16 +6,22 @@ A tool that reflects the Docker client [engine-api](https://github.com/docker/en
 
 ## How to use:
 
-To update the source repositories please use the following from your `$GOPATH`:
+Use the update scripts from the repository root to fetch Docker API/client definitions for a specific [release tag](https://github.com/moby/moby/releases/) and regenerate [Docker.DotNet Models](../../src/Docker.DotNet/Models):
 
+```powershell
+.\tools\specgen\update-generated-code.ps1 -ReleaseTag docker-v29.1.5
 ```
-> go get -u github.com/moby/moby/api@<release-tag>
-> go get -u github.com/moby/moby/client@<release-tag>
+
+```bash
+./tools/specgen/update-generated-code.sh docker-v29.1.5
 ```
 
-Note: Since the docker library is not a go module the version go generates will look something like this  v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible even though this is for v19.03.13. The commit hash bd33bbf0497b matches the commit hash of docker v 19.03.13
+The scripts will:
 
-Once you have the latest engine-api, call `update-generated-code.cmd` or `./update-generated-code.sh` (depending on your Operating System) to update the models in the [Docker.DotNet/Models](../../src/Docker.DotNet/Models) directory.
+- update `github.com/moby/moby/api` and `github.com/moby/moby/client` to the given release tag,
+- build `specgen`,
+- remove existing `*.Generated.cs` model files,
+- regenerate model files into [Docker.DotNet/Models](../../src/Docker.DotNet/Models).
 
 ----
 
@@ -63,7 +69,7 @@ namespace Docker.DotNet.Models
 
         [JsonPropertyName("Domainname")]
         public string Domainname { get; set; }
-        
+
         // etc...
     }
 }
@@ -71,7 +77,7 @@ namespace Docker.DotNet.Models
 
 Here you are actually seeing that the field values are marshalled in the request body based on the `JsonPropertyName` attribute. The resulting `JSON` will not contain the field if its value is equal to its default value in C#.
 
-A few customizations are taken in order to simplify the API even more. Take for example [RestartPolicyKind.cs](../../src/Docker.DotNet/Models/RestartPolicyKind.cs). You will see the generated model contains: 
+A few customizations are taken in order to simplify the API even more. Take for example [RestartPolicyKind.cs](../../src/Docker.DotNet/Models/RestartPolicyKind.cs). You will see the generated model contains:
 
 ```C#
 namespace Docker.DotNet.Models

--- a/tools/specgen/update-generated-code.cmd
+++ b/tools/specgen/update-generated-code.cmd
@@ -1,3 +1,0 @@
-go build
-specgen.exe ..\..\src\Docker.DotNet\Models
-del specgen.exe

--- a/tools/specgen/update-generated-code.ps1
+++ b/tools/specgen/update-generated-code.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0, HelpMessage = "Release tag to use for moby api/client (example: docker-v29.1.5)")]
+    [ValidateNotNullOrEmpty()]
+    [string]$ReleaseTag
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = $PSScriptRoot
+$modelsDir = Resolve-Path (Join-Path $scriptDir '..\..\src\Docker.DotNet\Models')
+$specgenExe = Join-Path $scriptDir 'specgen.exe'
+
+Push-Location $scriptDir
+
+try {
+    Write-Host "Updating moby api package to tag '$ReleaseTag'"
+    go get -u "github.com/moby/moby/api@$ReleaseTag"
+
+    Write-Host "Updating moby client package to tag '$ReleaseTag'"
+    go get -u "github.com/moby/moby/client@$ReleaseTag"
+
+    Write-Host 'Building specgen'
+    go build
+
+    Write-Host "Deleting existing generated model classes in '$modelsDir'"
+    Get-ChildItem -Path $modelsDir -Filter '*.Generated.cs' -File | Remove-Item -Force
+
+    Write-Host 'Regenerating model classes'
+    & $specgenExe $modelsDir
+}
+finally {
+    Pop-Location
+}

--- a/tools/specgen/update-generated-code.sh
+++ b/tools/specgen/update-generated-code.sh
@@ -1,3 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <release-tag>"
+    echo "Example: $0 docker-v29.1.5"
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+fi
+
+release_tag="$1"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+models_dir="$(cd "$script_dir/../../src/Docker.DotNet/Models" && pwd)"
+specgen_bin="$script_dir/specgen"
+
+pushd "$script_dir" > /dev/null
+
+trap 'popd > /dev/null || true' EXIT
+
+echo "Updating moby api package to tag '$release_tag'"
+go get -u "github.com/moby/moby/api@$release_tag"
+
+echo "Updating moby client package to tag '$release_tag'"
+go get -u "github.com/moby/moby/client@$release_tag"
+
+echo "Building specgen"
 go build
-./specgen ../../src/Docker.DotNet/Models
-rm specgen
+
+echo "Deleting existing generated model classes in '$models_dir'"
+find "$models_dir" -maxdepth 1 -type f -name '*.Generated.cs' -delete
+
+echo "Regenerating model classes"
+"$specgen_bin" "$models_dir"


### PR DESCRIPTION
The PR adds/updates the scripts `tools/specgen/update-generated-code.ps1` and `tools/specgen/update-generated-code.sh`. The scripts now expect the [release tag](https://github.com/moby/moby/releases/) (e.g. `docker-v29.1.5`) and then update the Docker API/client definitions, build the binary, and update the generated model classes in one step. Previously, manual steps were necessary.

If the Docker API/client definitions contain breaking changes, building the binary may fail. It is still necessary to review the Go sources and check if anything is marked as deprecated and requires further adjustments.