### PR TITLE
perf: Avoid creating a dictionary in QueryString and build it directly instead

### DIFF
--- a/src/Docker.DotNet/QueryString.cs
+++ b/src/Docker.DotNet/QueryString.cs
@@ -27,39 +27,42 @@ T> : IQueryString where T : class
     /// <returns></returns>
     public string GetQueryString()
     {
-        var sb = new StringBuilder();
-        foreach (var pair in AttributedPublicProperties)
+        var queryStringBuilder = new StringBuilder();
+
+        foreach (var attributedProperty in AttributedPublicProperties)
         {
-            var property = pair.Key;
-            var attribute = pair.Value;
+            var property = attributedProperty.Key;
+            var attribute = attributedProperty.Value;
+
             var value = property.GetValue(Object, null);
 
             // 'Required' check
             if (attribute.IsRequired && value == null)
             {
-                string propertyFullName = $"{property.DeclaringType?.FullName}.{property.Name}";
+                var propertyFullName = $"{property.DeclaringType?.FullName}.{property.Name}";
                 throw new ArgumentException("Got null/unset value for a required query parameter.", propertyFullName);
             }
 
-            // Serialize
+            // Serialization
             if (attribute.IsRequired || !IsDefaultOfType(value))
             {
-                var keyStr = attribute.Name;
+                var queryParameterName = attribute.Name;
 
-                foreach (var valueStr in attribute.Convert(value!))
+                foreach (var queryParameterValue in attribute.Convert(value!))
                 {
-                    if (sb.Length > 0)
+                    if (queryStringBuilder.Length > 0)
                     {
-                        sb.Append('&');
+                        queryStringBuilder.Append('&');
                     }
-                    sb.Append(Uri.EscapeDataString(keyStr));
-                    sb.Append('=');
-                    sb.Append(Uri.EscapeDataString(valueStr));
+
+                    queryStringBuilder.Append(Uri.EscapeDataString(queryParameterName));
+                    queryStringBuilder.Append('=');
+                    queryStringBuilder.Append(Uri.EscapeDataString(queryParameterValue));
                 }
             }
         }
 
-        return sb.ToString();
+        return queryStringBuilder.ToString();
     }
 
     private static Dictionary<PropertyInfo, TAttribType> FindAttributedPublicProperties<

--- a/src/Docker.DotNet/QueryString.cs
+++ b/src/Docker.DotNet/QueryString.cs
@@ -21,9 +21,13 @@ T> : IQueryString where T : class
         AttributedPublicProperties = FindAttributedPublicProperties<T, QueryStringParameterAttribute>();
     }
 
-    public IDictionary<string, string[]> GetKeyValuePairs()
+    /// <summary>
+    /// Returns formatted query string.
+    /// </summary>
+    /// <returns></returns>
+    public string GetQueryString()
     {
-        var queryParameters = new Dictionary<string, string[]>();
+        var sb = new StringBuilder();
         foreach (var pair in AttributedPublicProperties)
         {
             var property = pair.Key;
@@ -41,26 +45,21 @@ T> : IQueryString where T : class
             if (attribute.IsRequired || !IsDefaultOfType(value))
             {
                 var keyStr = attribute.Name;
-                var valueStr = attribute.Convert(value!);
 
-                queryParameters[keyStr] = valueStr;
+                foreach (var valueStr in attribute.Convert(value!))
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.Append('&');
+                    }
+                    sb.Append(Uri.EscapeDataString(keyStr));
+                    sb.Append('=');
+                    sb.Append(Uri.EscapeDataString(valueStr));
+                }
             }
         }
 
-        return queryParameters;
-    }
-
-    /// <summary>
-    /// Returns formatted query string.
-    /// </summary>
-    /// <returns></returns>
-    public string GetQueryString()
-    {
-        return string.Join("&",
-            GetKeyValuePairs().Select(
-                pair => string.Join("&",
-                    pair.Value.Select(
-                        v => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(v)}"))));
+        return sb.ToString();
     }
 
     private static Dictionary<PropertyInfo, TAttribType> FindAttributedPublicProperties<

--- a/src/Docker.DotNet/QueryStringBoolParameterAttribute.cs
+++ b/src/Docker.DotNet/QueryStringBoolParameterAttribute.cs
@@ -2,7 +2,7 @@ namespace Docker.DotNet;
 
 internal sealed class QueryStringBoolParameterAttribute(string name, bool required) : QueryStringParameterAttribute(name, required)
 {
-    public override string[] Convert(object value)
+    public override IEnumerable<string> Convert(object value)
     {
         Debug.Assert(value != null);
 

--- a/src/Docker.DotNet/QueryStringListParameterAttribute.cs
+++ b/src/Docker.DotNet/QueryStringListParameterAttribute.cs
@@ -2,7 +2,7 @@ namespace Docker.DotNet;
 
 internal sealed class QueryStringListParameterAttribute(string name, bool required) : QueryStringParameterAttribute(name, required)
 {
-    public override string[] Convert(object value)
+    public override IEnumerable<string> Convert(object value)
     {
         Debug.Assert(value != null);
         Debug.Assert(value is IList<string>);
@@ -12,6 +12,6 @@ internal sealed class QueryStringListParameterAttribute(string name, bool requir
             throw new ArgumentException($"Expected value of type '{typeof(IList<string>)}'.", nameof(value));
         }
 
-        return typedValue.ToArray();
+        return typedValue;
     }
 }

--- a/src/Docker.DotNet/QueryStringMapParameterAttribute.cs
+++ b/src/Docker.DotNet/QueryStringMapParameterAttribute.cs
@@ -2,7 +2,7 @@ namespace Docker.DotNet;
 
 internal sealed class QueryStringMapParameterAttribute<T>(string name, bool required) : QueryStringParameterAttribute(name, required)
 {
-    public override string[] Convert(object value)
+    public override IEnumerable<string> Convert(object value)
     {
         Debug.Assert(value != null);
         Debug.Assert(value is T);

--- a/src/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/src/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -7,7 +7,7 @@ internal class QueryStringParameterAttribute : Attribute
 
     public bool IsRequired { get; private set; }
 
-    public virtual string[] Convert(object value) => [value.ToString()!];
+    public virtual IEnumerable<string> Convert(object value) => [value.ToString()!];
 
     public QueryStringParameterAttribute(string name, bool required)
     {


### PR DESCRIPTION
use IEnumerable to avoid array creation in QueryStringListParameterAttribute