### PR TITLE
chore: Remove Docker_IsRunning test

### DIFF
--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -13,13 +13,6 @@ public class ISystemOperationsTests
     }
 
     [Fact]
-    public void Docker_IsRunning()
-    {
-        var dockerProcess = Process.GetProcesses().FirstOrDefault(process => process.ProcessName.Equals("docker", StringComparison.InvariantCultureIgnoreCase) || process.ProcessName.Equals("dockerd", StringComparison.InvariantCultureIgnoreCase));
-        Assert.NotNull(dockerProcess);
-    }
-
-    [Fact]
     public async Task GetSystemInfoAsync_Succeeds()
     {
         var info = await _testFixture.DockerClient.System.GetSystemInfoAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
Most tests will fail if Docker is not running anyway. And if using an alternative Docker engine (e.g. OrbStack configured with the `DOCKER_HOST` env var) then all tests will pass except for this Docker_IsRunning test.