### PR TITLE
chore: Defer Docker endpoint resolution until the client is built

### DIFF
--- a/src/Docker.DotNet.Handler.Abstractions/IDockerHandlerFactory.cs
+++ b/src/Docker.DotNet.Handler.Abstractions/IDockerHandlerFactory.cs
@@ -11,5 +11,5 @@ public interface IDockerHandlerFactory : IStreamHijacker
     /// <param name="clientOptions">The client options.</param>
     /// <param name="logger">The logger instance.</param>
     /// <returns>The resolved transport.</returns>
-    ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger);
+    ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger);
 }

--- a/src/Docker.DotNet.Handler.Abstractions/IDockerHandlerFactory`1.cs
+++ b/src/Docker.DotNet.Handler.Abstractions/IDockerHandlerFactory`1.cs
@@ -13,5 +13,5 @@ public interface IDockerHandlerFactory<in TTransportOptions> : IDockerHandlerFac
     /// <param name="clientOptions">The client options.</param>
     /// <param name="logger">The logger instance.</param>
     /// <returns>The resolved transport.</returns>
-    ResolvedTransport CreateHandler(TTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger);
+    ResolvedTransport CreateHandler(TTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger);
 }

--- a/src/Docker.DotNet.Handler.Abstractions/ResolvedClientOptions.cs
+++ b/src/Docker.DotNet.Handler.Abstractions/ResolvedClientOptions.cs
@@ -1,9 +1,9 @@
 namespace Docker.DotNet.Handler.Abstractions;
 
 /// <summary>
-/// Represents the options used to configure a Docker client builder.
+/// Represents the resolved options used to configure a Docker client connection.
 /// </summary>
-public sealed record ClientOptions
+public sealed record ResolvedClientOptions
 {
     /// <summary>
     /// Gets the Docker Engine API version to request.
@@ -11,10 +11,9 @@ public sealed record ClientOptions
     public Version? ApiVersion { get; init; }
 
     /// <summary>
-    /// Gets the endpoint URI to connect to, or <see langword="null"/> to resolve the
-    /// default Docker endpoint when the client is built.
+    /// Gets the resolved endpoint URI to connect to.
     /// </summary>
-    public Uri? Endpoint { get; init; }
+    public Uri Endpoint { get; init; } = null!;
 
     /// <summary>
     /// Gets the authentication provider used to configure the HTTP handler.

--- a/src/Docker.DotNet.LegacyHttp/DockerHandlerFactory.cs
+++ b/src/Docker.DotNet.LegacyHttp/DockerHandlerFactory.cs
@@ -9,19 +9,25 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<LegacyHttpTrans
     public static IDockerHandlerFactory<LegacyHttpTransportOptions> Instance { get; }
         = new DockerHandlerFactory();
 
-    public ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger)
     {
         var transportOptions = new LegacyHttpTransportOptions();
-        Validate(transportOptions, clientOptions);
         return CreateHandler(transportOptions, clientOptions, logger);
     }
 
-    public ResolvedTransport CreateHandler(LegacyHttpTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(LegacyHttpTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger)
     {
-        Validate(transportOptions, clientOptions);
+        if (clientOptions is null)
+        {
+            throw new ArgumentNullException(nameof(clientOptions));
+        }
+
+        var endpoint = clientOptions.Endpoint;
+
+        Validate(endpoint);
 
         var scheme = clientOptions.AuthProvider.TlsEnabled ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
-        var uri = new UriBuilder(clientOptions.Endpoint) { Scheme = scheme }.Uri;
+        var uri = new UriBuilder(endpoint) { Scheme = scheme }.Uri;
         var handler = new ManagedHandler(logger);
         transportOptions.ConfigureHandler(handler);
 
@@ -38,14 +44,9 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<LegacyHttpTrans
         return Task.FromResult(hijackable.HijackStream());
     }
 
-    private static void Validate(LegacyHttpTransportOptions _, ClientOptions clientOptions)
+    private static void Validate(Uri endpoint)
     {
-        if (clientOptions.Endpoint is null)
-        {
-            throw new ArgumentNullException(nameof(clientOptions), "ClientOptions.Endpoint must be set.");
-        }
-
-        var scheme = clientOptions.Endpoint.Scheme;
+        var scheme = endpoint.Scheme;
 
         if (!string.Equals(scheme, "tcp", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)

--- a/src/Docker.DotNet.NPipe/DockerHandlerFactory.cs
+++ b/src/Docker.DotNet.NPipe/DockerHandlerFactory.cs
@@ -9,23 +9,27 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<NPipeTransportO
     public static IDockerHandlerFactory<NPipeTransportOptions> Instance { get; }
         = new DockerHandlerFactory();
 
-    public ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger)
     {
         var transportOptions = new NPipeTransportOptions();
-        Validate(transportOptions, clientOptions);
         return CreateHandler(transportOptions, clientOptions, logger);
     }
 
-    public ResolvedTransport CreateHandler(NPipeTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(NPipeTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger)
     {
-        Validate(transportOptions, clientOptions);
+        if (clientOptions is null)
+        {
+            throw new ArgumentNullException(nameof(clientOptions));
+        }
+
+        var uri = clientOptions.Endpoint;
+
+        Validate(uri);
 
         if (clientOptions.AuthProvider.TlsEnabled)
         {
             throw new NotSupportedException("TLS is not supported over npipe.");
         }
-
-        var uri = clientOptions.Endpoint;
 
         var segments = uri.Segments;
 
@@ -73,14 +77,9 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<NPipeTransportO
         return Task.FromResult(hijackable.HijackStream());
     }
 
-    private static void Validate(NPipeTransportOptions _, ClientOptions clientOptions)
+    private static void Validate(Uri endpoint)
     {
-        if (clientOptions.Endpoint is null)
-        {
-            throw new ArgumentNullException(nameof(clientOptions), "ClientOptions.Endpoint must be set.");
-        }
-
-        var scheme = clientOptions.Endpoint.Scheme;
+        var scheme = endpoint.Scheme;
 
         if (!string.Equals(scheme, "npipe", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Docker.DotNet.NativeHttp/DockerHandlerFactory.cs
+++ b/src/Docker.DotNet.NativeHttp/DockerHandlerFactory.cs
@@ -15,19 +15,25 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<NativeHttpTrans
     public static IDockerHandlerFactory<NativeHttpTransportOptions> Instance { get; }
         = new DockerHandlerFactory();
 
-    public ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger)
     {
         var transportOptions = new NativeHttpTransportOptions();
-        Validate(transportOptions, clientOptions);
         return CreateHandler(transportOptions, clientOptions, logger);
     }
 
-    public ResolvedTransport CreateHandler(NativeHttpTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(NativeHttpTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger)
     {
-        Validate(transportOptions, clientOptions);
+        if (clientOptions is null)
+        {
+            throw new ArgumentNullException(nameof(clientOptions));
+        }
+
+        var endpoint = clientOptions.Endpoint;
+
+        Validate(endpoint);
 
         var scheme = clientOptions.AuthProvider.TlsEnabled ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
-        var uri = new UriBuilder(clientOptions.Endpoint) { Scheme = scheme }.Uri;
+        var uri = new UriBuilder(endpoint) { Scheme = scheme }.Uri;
 
 #if NET
         var handler = new SocketsHttpHandler
@@ -54,14 +60,9 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<NativeHttpTrans
         return new WriteClosableStreamWrapper(stream);
     }
 
-    private static void Validate(NativeHttpTransportOptions _, ClientOptions clientOptions)
+    private static void Validate(Uri endpoint)
     {
-        if (clientOptions.Endpoint is null)
-        {
-            throw new ArgumentNullException(nameof(clientOptions), "ClientOptions.Endpoint must be set.");
-        }
-
-        var scheme = clientOptions.Endpoint.Scheme;
+        var scheme = endpoint.Scheme;
 
         if (!string.Equals(scheme, "tcp", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)

--- a/src/Docker.DotNet.Unix/DockerHandlerFactory.cs
+++ b/src/Docker.DotNet.Unix/DockerHandlerFactory.cs
@@ -9,18 +9,22 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<UnixSocketTrans
     public static IDockerHandlerFactory<UnixSocketTransportOptions> Instance { get; }
         = new DockerHandlerFactory();
 
-    public ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger)
     {
         var transportOptions = new UnixSocketTransportOptions();
-        Validate(transportOptions, clientOptions);
         return CreateHandler(transportOptions, clientOptions, logger);
     }
 
-    public ResolvedTransport CreateHandler(UnixSocketTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger)
+    public ResolvedTransport CreateHandler(UnixSocketTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger)
     {
-        Validate(transportOptions, clientOptions);
+        if (clientOptions is null)
+        {
+            throw new ArgumentNullException(nameof(clientOptions));
+        }
 
         var uri = clientOptions.Endpoint;
+
+        Validate(uri);
 
         var socketName = uri.Segments.Last();
         var socketPath = uri.LocalPath;
@@ -59,14 +63,9 @@ public sealed class DockerHandlerFactory : IDockerHandlerFactory<UnixSocketTrans
         return Task.FromResult(hijackable.HijackStream());
     }
 
-    private static void Validate(UnixSocketTransportOptions _, ClientOptions clientOptions)
+    private static void Validate(Uri endpoint)
     {
-        if (clientOptions.Endpoint is null)
-        {
-            throw new ArgumentNullException(nameof(clientOptions), "ClientOptions.Endpoint must be set.");
-        }
-
-        var scheme = clientOptions.Endpoint.Scheme;
+        var scheme = endpoint.Scheme;
 
         if (!string.Equals(scheme, "unix", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -8,7 +8,7 @@ public sealed class DockerClient : IDockerClient
 
     private readonly HttpClient _client;
 
-    private readonly ClientOptions _clientOptions;
+    private readonly ResolvedClientOptions _clientOptions;
 
     private readonly Uri _effectiveEndpoint;
 
@@ -16,7 +16,7 @@ public sealed class DockerClient : IDockerClient
 
     internal DockerClient(
         HttpMessageHandler handler,
-        ClientOptions clientOptions,
+        ResolvedClientOptions clientOptions,
         Uri effectiveEndpoint,
         IStreamHijacker hijack)
     {
@@ -42,7 +42,7 @@ public sealed class DockerClient : IDockerClient
         Exec = new ExecOperations(this);
     }
 
-    public ClientOptions Options { get; }
+    public ResolvedClientOptions Options { get; }
 
     public ISystemOperations System { get; }
 

--- a/src/Docker.DotNet/DockerClientBuilder.cs
+++ b/src/Docker.DotNet/DockerClientBuilder.cs
@@ -38,7 +38,7 @@ public class DockerClientBuilder
     /// <param name="dockerConfig">The Docker config to preserve.</param>
     public DockerClientBuilder(
         DockerConfig dockerConfig)
-        : this(dockerConfig, new ClientOptions { Endpoint = dockerConfig.GetEndpoint() }, NullLogger.Instance)
+        : this(dockerConfig, new ClientOptions(), NullLogger.Instance)
     {
     }
 
@@ -255,13 +255,33 @@ public class DockerClientBuilder
     /// <returns>A configured <see cref="DockerClient"/> instance.</returns>
     public virtual DockerClient Build()
     {
-        var transportFactory = ResolveTransportFactory(ClientOptions.Endpoint.Scheme);
+        var clientOptions = CreateResolvedClientOptions();
 
-        var resolvedTransport = transportFactory.CreateHandler(ClientOptions, Logger);
+        var transportFactory = ResolveTransportFactory(clientOptions.Endpoint.Scheme);
 
-        var authenticatedHandler = ClientOptions.AuthProvider.ConfigureHandler(resolvedTransport.Handler);
+        var resolvedTransport = transportFactory.CreateHandler(clientOptions, Logger);
 
-        return new DockerClient(authenticatedHandler, ClientOptions, resolvedTransport.EffectiveEndpoint, transportFactory);
+        var authenticatedHandler = clientOptions.AuthProvider.ConfigureHandler(resolvedTransport.Handler);
+
+        return new DockerClient(authenticatedHandler, clientOptions, resolvedTransport.EffectiveEndpoint, transportFactory);
+    }
+
+    /// <summary>
+    /// Resolves the client options, falling back to the default Docker endpoint when none was configured.
+    /// </summary>
+    /// <returns>The client options with a resolved endpoint.</returns>
+    protected ResolvedClientOptions CreateResolvedClientOptions()
+    {
+        var endpoint = ClientOptions.Endpoint ?? _dockerConfig.GetEndpoint();
+
+        return new ResolvedClientOptions
+        {
+            ApiVersion = ClientOptions.ApiVersion,
+            Endpoint = endpoint,
+            AuthProvider = ClientOptions.AuthProvider,
+            Headers = ClientOptions.Headers,
+            Timeout = ClientOptions.Timeout,
+        };
     }
 
     /// <summary>

--- a/src/Docker.DotNet/DockerClientBuilder`1.cs
+++ b/src/Docker.DotNet/DockerClientBuilder`1.cs
@@ -66,10 +66,12 @@ public sealed class DockerClientBuilder<TTransportOptions> : DockerClientBuilder
     /// <returns>A configured <see cref="DockerClient"/> instance.</returns>
     public override DockerClient Build()
     {
-        var resolvedTransport = _transportFactory.CreateHandler(_transportOptions, ClientOptions, Logger);
+        var clientOptions = CreateResolvedClientOptions();
 
-        var authenticatedHandler = ClientOptions.AuthProvider.ConfigureHandler(resolvedTransport.Handler);
+        var resolvedTransport = _transportFactory.CreateHandler(_transportOptions, clientOptions, Logger);
 
-        return new DockerClient(authenticatedHandler, ClientOptions, resolvedTransport.EffectiveEndpoint, _transportFactory);
+        var authenticatedHandler = clientOptions.AuthProvider.ConfigureHandler(resolvedTransport.Handler);
+
+        return new DockerClient(authenticatedHandler, clientOptions, resolvedTransport.EffectiveEndpoint, _transportFactory);
     }
 }

--- a/src/Docker.DotNet/IDockerClient.cs
+++ b/src/Docker.DotNet/IDockerClient.cs
@@ -2,7 +2,7 @@ namespace Docker.DotNet;
 
 public interface IDockerClient : IDisposable
 {
-    ClientOptions Options { get; }
+    ResolvedClientOptions Options { get; }
 
     ISystemOperations System { get; }
 

--- a/test/Docker.DotNet.TestsV2/DockerClientBuilderTests.cs
+++ b/test/Docker.DotNet.TestsV2/DockerClientBuilderTests.cs
@@ -3,46 +3,6 @@ namespace Docker.DotNet.TestsV2;
 public sealed class DockerClientBuilderTests
 {
     [Fact]
-    public void UsesInjectedEndpointWhenBuiltWithoutExplicitEndpoint()
-    {
-        IDockerCliSettings settings = new TestDockerCliSettings
-        {
-            DockerHost = "tcp://127.0.0.1:2375/"
-        };
-
-        var transportFactory = new FakeTransportFactory();
-
-        _ = new TestDockerClientBuilder(new DockerConfig(settings))
-            .WithTransportOptions(transportFactory, new FakeTransportOptions())
-            .Build();
-
-        Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), transportFactory.LastClientOptions.Endpoint);
-    }
-
-    [Fact]
-    public void ResolvesDefaultEndpointWhenTypedBuilderIsBuilt()
-    {
-        var transportFactory = new FakeTransportFactory();
-
-        var transportOptions = new FakeTransportOptions();
-
-        var expectedEndpoint = DockerConfig.Instance.GetEndpoint();
-
-        _ = new DockerClientBuilder<FakeTransportOptions>(transportFactory, transportOptions)
-            .Build();
-
-        Assert.Equal(expectedEndpoint, transportFactory.LastClientOptions.Endpoint);
-    }
-
-    [Fact]
-    public void ResolvesDefaultEndpointWhenResolvedOptionsAreCreated()
-    {
-        var builder = new TestDockerClientBuilder();
-
-        Assert.Equal(DockerConfig.Instance.GetEndpoint(), builder.CreateResolvedClientOptions().Endpoint);
-    }
-
-    [Fact]
     public void UpdatesClientOptionsWhenApiVersionIsSet()
     {
         var version = new Version(1, 52);
@@ -67,7 +27,7 @@ public sealed class DockerClientBuilderTests
     }
 
     [Fact]
-    public void UsesInjectedDockerConfigWhenContextIsSet()
+    public void UpdatesClientOptionsWhenContextIsSet()
     {
         using var context = new ConfigMetaFile("custom", new Uri("tcp://127.0.0.1:2375/"));
 
@@ -78,30 +38,10 @@ public sealed class DockerClientBuilderTests
 
         var builder = new TestDockerClientBuilder(new DockerConfig(settings));
 
-        _ = builder.WithContext("custom");
+        var sameInstance = builder.WithContext("custom");
 
+        Assert.Same(builder, sameInstance);
         Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), builder.ClientOptions.Endpoint);
-    }
-
-    [Fact]
-    public void SkipsDockerConfigDiscoveryWhenExplicitEndpointIsSet()
-    {
-        IDockerCliSettings settings = new TestDockerCliSettings
-        {
-            DockerConfig = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")),
-            DockerContext = "missing"
-        };
-
-        var transportFactory = new FakeTransportFactory();
-
-        var explicitEndpoint = new Uri("http://localhost:2375");
-
-        _ = new TestDockerClientBuilder(new DockerConfig(settings))
-            .WithEndpoint(explicitEndpoint)
-            .WithTransportOptions(transportFactory, new FakeTransportOptions())
-            .Build();
-
-        Assert.Equal(explicitEndpoint, transportFactory.LastClientOptions.Endpoint);
     }
 
     [Fact]
@@ -190,6 +130,81 @@ public sealed class DockerClientBuilderTests
     }
 
     [Fact]
+    public void ResolvesDefaultEndpointWhenResolvedOptionsAreCreated()
+    {
+        var builder = new TestDockerClientBuilder();
+
+        Assert.Equal(DockerConfig.Instance.GetEndpoint(), builder.CreateResolvedClientOptions().Endpoint);
+    }
+
+    [Fact]
+    public void UsesInjectedEndpointWhenBuiltWithoutExplicitEndpoint()
+    {
+        IDockerCliSettings settings = new TestDockerCliSettings
+        {
+            DockerHost = "tcp://127.0.0.1:2375/"
+        };
+
+        var transportFactory = new FakeTransportFactory();
+
+        using var _ = new TestDockerClientBuilder(new DockerConfig(settings))
+            .WithTransportOptions(transportFactory, new FakeTransportOptions())
+            .Build();
+
+        Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), transportFactory.LastClientOptions.Endpoint);
+    }
+
+    [Fact]
+    public void ResolvesDefaultEndpointWhenTypedBuilderIsBuilt()
+    {
+        var transportFactory = new FakeTransportFactory();
+
+        var transportOptions = new FakeTransportOptions();
+
+        var expectedEndpoint = DockerConfig.Instance.GetEndpoint();
+
+        using var _ = new DockerClientBuilder<FakeTransportOptions>(transportFactory, transportOptions)
+            .Build();
+
+        Assert.Equal(expectedEndpoint, transportFactory.LastClientOptions.Endpoint);
+    }
+
+    [Fact]
+    public void ResolvesEndpointAndTransportFactoryWhenNonTypedBuilderIsBuilt()
+    {
+        IDockerCliSettings settings = new TestDockerCliSettings
+        {
+            DockerHost = "tcp://127.0.0.1:2375/"
+        };
+
+        using var client = new TestDockerClientBuilder(new DockerConfig(settings))
+            .Build();
+
+        Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), client.Options.Endpoint);
+    }
+
+    [Fact]
+    public void SkipsDockerConfigDiscoveryWhenExplicitEndpointIsSet()
+    {
+        IDockerCliSettings settings = new TestDockerCliSettings
+        {
+            DockerConfig = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")),
+            DockerContext = "missing"
+        };
+
+        var transportFactory = new FakeTransportFactory();
+
+        var explicitEndpoint = new Uri("http://localhost:2375");
+
+        using var _ = new TestDockerClientBuilder(new DockerConfig(settings))
+            .WithEndpoint(explicitEndpoint)
+            .WithTransportOptions(transportFactory, new FakeTransportOptions())
+            .Build();
+
+        Assert.Equal(explicitEndpoint, transportFactory.LastClientOptions.Endpoint);
+    }
+
+    [Fact]
     public void PreservesClientOptionsAndLoggerWhenConfiguredBeforeTransportSelection()
     {
         var transportFactory = new FakeTransportFactory();
@@ -205,7 +220,7 @@ public sealed class DockerClientBuilderTests
         var timeout = TimeSpan.FromSeconds(1);
         var logger = NullLogger.Instance;
 
-        _ = new DockerClientBuilder()
+        using var _ = new DockerClientBuilder()
             .WithApiVersion(apiVersion)
             .WithEndpoint(endpoint)
             .WithAuthProvider(authProvider)
@@ -241,7 +256,7 @@ public sealed class DockerClientBuilderTests
         var timeout = TimeSpan.FromSeconds(5);
         var logger = NullLogger.Instance;
 
-        _ = new DockerClientBuilder()
+        using var _ = new DockerClientBuilder()
             .WithTransportOptions(transportFactory, transportOptions)
             .WithApiVersion(apiVersion)
             .WithEndpoint(endpoint)
@@ -270,23 +285,12 @@ public sealed class DockerClientBuilderTests
 
         var expectedEndpoint = new Uri("npipe://./pipe/docker_engine");
 
-        _ = new DockerClientBuilder()
+        using var _ = new DockerClientBuilder()
             .WithTransportOptions(transportFactory, transportOptions)
             .WithEndpoint(expectedEndpoint)
             .Build();
 
         Assert.Equal(expectedEndpoint, transportFactory.LastClientOptions.Endpoint);
-    }
-
-    [Fact]
-    public void ThrowsWhenUnsupportedSchemeIsBuilt()
-    {
-        var builder = new DockerClientBuilder()
-            .WithEndpoint(new Uri("ssh://docker-host"));
-
-        var exception = Assert.Throws<SshDockerEndpointNotSupportedException>(builder.Build);
-
-        Assert.Contains("ssh", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -301,18 +305,43 @@ public sealed class DockerClientBuilderTests
         Assert.IsType(expectedFactoryType, actualFactory);
     }
 
-    [Fact]
-    public void UsesExpectedFactoryWhenHttpSchemeIsProvided()
+    [Theory]
+    [InlineData("tcp://localhost:2375")]
+    [InlineData("http://localhost:2375")]
+    [InlineData("https://localhost:2375")]
+    public void UsesExpectedFactoryWhenHttpSchemeIsProvided(string endpoint)
     {
         var builder = new TestDockerClientBuilder();
 
-        var actualFactory = builder.ResolveTransportFactory(new Uri("http://localhost:2375"));
+        var actualFactory = builder.ResolveTransportFactory(new Uri(endpoint));
 
         var expectedFactoryType = Environment.GetEnvironmentVariable("DOCKER_DOTNET_NATIVE_HTTP_ENABLED") == "1"
             ? typeof(NativeHttp.DockerHandlerFactory)
             : typeof(LegacyHttp.DockerHandlerFactory);
 
         Assert.IsType(expectedFactoryType, actualFactory);
+    }
+
+    [Fact]
+    public void ThrowsWhenUnsupportedSchemeIsBuilt()
+    {
+        var builder = new DockerClientBuilder();
+
+        _ = builder.WithEndpoint(new Uri("ssh://localhost"));
+
+        var exception = Assert.Throws<SshDockerEndpointNotSupportedException>(builder.Build);
+
+        Assert.Contains("ssh", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ThrowsWhenUnknownSchemeIsResolved()
+    {
+        var builder = new TestDockerClientBuilder();
+
+        var exception = Assert.Throws<NotSupportedException>(() => builder.ResolveTransportFactory(new Uri("ftp://docker-host")));
+
+        Assert.Contains("ftp", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class TestDockerClientBuilder : DockerClientBuilder

--- a/test/Docker.DotNet.TestsV2/DockerClientBuilderTests.cs
+++ b/test/Docker.DotNet.TestsV2/DockerClientBuilderTests.cs
@@ -3,31 +3,43 @@ namespace Docker.DotNet.TestsV2;
 public sealed class DockerClientBuilderTests
 {
     [Fact]
-    public void ReturnsInjectedEndpointWhenConstructedWithDockerConfig()
+    public void UsesInjectedEndpointWhenBuiltWithoutExplicitEndpoint()
     {
         IDockerCliSettings settings = new TestDockerCliSettings
         {
             DockerHost = "tcp://127.0.0.1:2375/"
         };
 
-        var builder = new TestDockerClientBuilder(new DockerConfig(settings));
+        var transportFactory = new FakeTransportFactory();
 
-        Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), builder.ClientOptions.Endpoint);
+        _ = new TestDockerClientBuilder(new DockerConfig(settings))
+            .WithTransportOptions(transportFactory, new FakeTransportOptions())
+            .Build();
+
+        Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), transportFactory.LastClientOptions.Endpoint);
     }
 
     [Fact]
-    public void ReturnsDefaultEndpointWhenTypedBuilderIsConstructed()
+    public void ResolvesDefaultEndpointWhenTypedBuilderIsBuilt()
     {
         var transportFactory = new FakeTransportFactory();
 
         var transportOptions = new FakeTransportOptions();
 
-        var expectedEndpoint = new TestDockerClientBuilder().ClientOptions.Endpoint;
+        var expectedEndpoint = DockerConfig.Instance.GetEndpoint();
 
         _ = new DockerClientBuilder<FakeTransportOptions>(transportFactory, transportOptions)
             .Build();
 
         Assert.Equal(expectedEndpoint, transportFactory.LastClientOptions.Endpoint);
+    }
+
+    [Fact]
+    public void ResolvesDefaultEndpointWhenResolvedOptionsAreCreated()
+    {
+        var builder = new TestDockerClientBuilder();
+
+        Assert.Equal(DockerConfig.Instance.GetEndpoint(), builder.CreateResolvedClientOptions().Endpoint);
     }
 
     [Fact]
@@ -69,6 +81,27 @@ public sealed class DockerClientBuilderTests
         _ = builder.WithContext("custom");
 
         Assert.Equal(new Uri("tcp://127.0.0.1:2375/"), builder.ClientOptions.Endpoint);
+    }
+
+    [Fact]
+    public void SkipsDockerConfigDiscoveryWhenExplicitEndpointIsSet()
+    {
+        IDockerCliSettings settings = new TestDockerCliSettings
+        {
+            DockerConfig = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")),
+            DockerContext = "missing"
+        };
+
+        var transportFactory = new FakeTransportFactory();
+
+        var explicitEndpoint = new Uri("http://localhost:2375");
+
+        _ = new TestDockerClientBuilder(new DockerConfig(settings))
+            .WithEndpoint(explicitEndpoint)
+            .WithTransportOptions(transportFactory, new FakeTransportOptions())
+            .Build();
+
+        Assert.Equal(explicitEndpoint, transportFactory.LastClientOptions.Endpoint);
     }
 
     [Fact]
@@ -299,6 +332,9 @@ public sealed class DockerClientBuilderTests
         public new ILogger Logger
             => base.Logger;
 
+        public new ResolvedClientOptions CreateResolvedClientOptions()
+            => base.CreateResolvedClientOptions();
+
         public IDockerHandlerFactory ResolveTransportFactory(Uri endpoint)
             => base.ResolveTransportFactory(endpoint.Scheme);
     }
@@ -329,11 +365,11 @@ public sealed class DockerClientBuilderTests
 
         public FakeTransportOptions LastTransportOptions { get; private set; } = null!;
 
-        public ClientOptions LastClientOptions { get; private set; } = null!;
+        public ResolvedClientOptions LastClientOptions { get; private set; } = null!;
 
         public ILogger LastLogger { get; private set; } = null!;
 
-        public ResolvedTransport CreateHandler(FakeTransportOptions transportOptions, ClientOptions clientOptions, ILogger logger)
+        public ResolvedTransport CreateHandler(FakeTransportOptions transportOptions, ResolvedClientOptions clientOptions, ILogger logger)
         {
             TypedCreateHandlerCallCount++;
             LastTransportOptions = transportOptions;
@@ -343,7 +379,7 @@ public sealed class DockerClientBuilderTests
             return new ResolvedTransport(new HttpClientHandler(), clientOptions.Endpoint);
         }
 
-        public ResolvedTransport CreateHandler(ClientOptions clientOptions, ILogger logger)
+        public ResolvedTransport CreateHandler(ResolvedClientOptions clientOptions, ILogger logger)
             => throw new NotSupportedException();
 
         public Task<WriteClosableStream> HijackStreamAsync(HttpContent content)

--- a/test/Docker.DotNet.TestsV2/DockerHandlerFactoryValidationTests.cs
+++ b/test/Docker.DotNet.TestsV2/DockerHandlerFactoryValidationTests.cs
@@ -2,25 +2,7 @@ namespace Docker.DotNet.TestsV2;
 
 public sealed class DockerHandlerFactoryValidationTests
 {
-    public static TheoryData<Func<ClientOptions, ResolvedTransport>>
-        EndpointRequiredCases =>
-        new()
-        {
-            {
-                options => LegacyHttp.DockerHandlerFactory.Instance.CreateHandler(options, NullLogger.Instance)
-            },
-            {
-                options => NativeHttp.DockerHandlerFactory.Instance.CreateHandler(options, NullLogger.Instance)
-            },
-            {
-                options => NPipe.DockerHandlerFactory.Instance.CreateHandler(options, NullLogger.Instance)
-            },
-            {
-                options => Unix.DockerHandlerFactory.Instance.CreateHandler(options, NullLogger.Instance)
-            },
-        };
-
-    public static TheoryData<Func<ClientOptions, ResolvedTransport>, Uri, string, string>
+    public static TheoryData<Func<ResolvedClientOptions, ResolvedTransport>, Uri, string, string>
         InvalidSchemeCases =>
         new()
         {
@@ -51,27 +33,14 @@ public sealed class DockerHandlerFactoryValidationTests
         };
 
     [Theory]
-    [MemberData(nameof(EndpointRequiredCases))]
-    public void CreateHandler_ThrowsArgumentNullException_WhenEndpointIsNull(
-        Func<ClientOptions, ResolvedTransport> createHandler)
-    {
-        var clientOptions = new ClientOptions();
-
-        var exception = Assert.Throws<ArgumentNullException>(() => createHandler(clientOptions));
-
-        Assert.Equal("clientOptions", exception.ParamName);
-        Assert.Contains("Endpoint", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Theory]
     [MemberData(nameof(InvalidSchemeCases))]
     public void CreateHandler_ThrowsInvalidOperationException_WhenSchemeDoesNotMatchTransport(
-        Func<ClientOptions, ResolvedTransport> createHandler,
+        Func<ResolvedClientOptions, ResolvedTransport> createHandler,
         Uri endpoint,
         string transportOptionsName,
         string expectedSchemesFragment)
     {
-        var clientOptions = new ClientOptions { Endpoint = endpoint };
+        var clientOptions = new ResolvedClientOptions { Endpoint = endpoint };
 
         var exception = Assert.Throws<InvalidOperationException>(() => createHandler(clientOptions));
 


### PR DESCRIPTION
This PR specifically addresses an issue related to Testcontainers. Testcontainers includes its own Docker endpoint discovery mechanism. As we have started moving this functionality into Docker.DotNet, where it ultimately belongs, applications that use both Docker.DotNet and Testcontainers may end up running similar endpoint discovery logic twice.

To reduce this overhead, this PR defers Docker.DotNet's endpoint resolution so that libraries implementing their own discovery mechanism are prioritized. This avoids unnecessary duplicate resolution while the migration is still in progress.

Once all endpoint discovery functionality has been consolidated into Docker.DotNet, this workaround can be removed.