### PR TITLE
fix: Replace generic QueryStringMapParameter attribute with Type argument

### DIFF
--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -45,6 +45,11 @@ internal sealed class JsonSerializer
         return System.Text.Json.JsonSerializer.Serialize(value, JsonTypeInfoCache<T>.Value);
     }
 
+    public string Serialize(object? value, Type type)
+    {
+        return System.Text.Json.JsonSerializer.Serialize(value, _options.GetTypeInfo(type));
+    }
+
     public byte[] SerializeToUtf8Bytes<T>(T value)
     {
         return System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(value, JsonTypeInfoCache<T>.Value);

--- a/src/Docker.DotNet/Models/ContainerEventsParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerEventsParameters.Generated.cs
@@ -9,7 +9,7 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("until", false)]
         public string? Until { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ContainersListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainersListParameters.Generated.cs
@@ -12,7 +12,7 @@ namespace Docker.DotNet.Models
         [QueryStringBoolParameter("size", false)]
         public bool? Size { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ContainersPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainersPruneParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class ContainersPruneParameters // (main.ContainersPruneParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
@@ -51,10 +51,10 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("dockerfile", false)]
         public string? Dockerfile { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, string>>("buildargs", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, string>), "buildargs", false)]
         public IDictionary<string, string>? BuildArgs { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, string>>("labels", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, string>), "labels", false)]
         public IDictionary<string, string>? Labels { get; set; }
 
         [QueryStringBoolParameter("squash", false)]

--- a/src/Docker.DotNet/Models/ImagesListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesListParameters.Generated.cs
@@ -6,7 +6,7 @@ namespace Docker.DotNet.Models
         [QueryStringBoolParameter("all", false)]
         public bool? All { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
 
         [QueryStringBoolParameter("shared-size", false)]

--- a/src/Docker.DotNet/Models/ImagesPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesPruneParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class ImagesPruneParameters // (main.ImagesPruneParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ImagesSearchParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImagesSearchParameters.Generated.cs
@@ -9,7 +9,7 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("limit", false)]
         public long? Limit { get; set; }
 
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/NetworksDeleteUnusedParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksDeleteUnusedParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class NetworksDeleteUnusedParameters // (main.NetworksDeleteUnusedParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/NetworksListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/NetworksListParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class NetworksListParameters // (main.NetworksListParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/PluginListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/PluginListParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class PluginListParameters // (main.PluginListParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/ServiceListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ServiceListParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class ServiceListParameters // (main.ServiceListParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
 
         [QueryStringBoolParameter("status", false)]

--- a/src/Docker.DotNet/Models/TasksListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/TasksListParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class TasksListParameters // (main.TasksListParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/VolumesListParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesListParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class VolumesListParameters // (main.VolumesListParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/Models/VolumesPruneParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/VolumesPruneParameters.Generated.cs
@@ -3,7 +3,7 @@ namespace Docker.DotNet.Models
 {
     public class VolumesPruneParameters // (main.VolumesPruneParameters)
     {
-        [QueryStringMapParameter<IDictionary<string, IDictionary<string, bool>>>("filters", false)]
+        [QueryStringMapParameter(typeof(IDictionary<string, IDictionary<string, bool>>), "filters", false)]
         public IDictionary<string, IDictionary<string, bool>>? Filters { get; set; }
     }
 }

--- a/src/Docker.DotNet/QueryStringMapParameterAttribute.cs
+++ b/src/Docker.DotNet/QueryStringMapParameterAttribute.cs
@@ -1,17 +1,17 @@
 namespace Docker.DotNet;
 
-internal sealed class QueryStringMapParameterAttribute<T>(string name, bool required) : QueryStringParameterAttribute(name, required)
+internal sealed class QueryStringMapParameterAttribute(Type type, string name, bool required) : QueryStringParameterAttribute(name, required)
 {
     public override IEnumerable<string> Convert(object value)
     {
         Debug.Assert(value != null);
-        Debug.Assert(value is T);
+        Debug.Assert(type.IsInstanceOfType(value));
 
-        if (value is not T typedValue)
+        if (!type.IsInstanceOfType(value))
         {
-            throw new ArgumentException($"Expected value of type '{typeof(T)}'.", nameof(value));
+            throw new ArgumentException($"Expected value of type '{type}'.", nameof(value));
         }
 
-        return [JsonSerializer.Instance.Serialize(typedValue)];
+        return [JsonSerializer.Instance.Serialize(value, type)];
     }
 }

--- a/tools/Docker.DotNet.SourceAnalyzers/JsonSerializerAnalyzer.cs
+++ b/tools/Docker.DotNet.SourceAnalyzers/JsonSerializerAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class JsonSerializerAnalyzer : DiagnosticAnalyzer
         // Handle new JsonRequestContent<T>.
         context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
 
-        // Handle [QueryStringMapParameter<T>(...)].
+        // Handle [QueryStringMapParameter(typeof(T), ...)].
         context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
     }
 
@@ -89,9 +89,25 @@ public sealed class JsonSerializerAnalyzer : DiagnosticAnalyzer
             typeSymbol.Name == "QueryStringMapParameterAttribute" &&
             typeSymbol.ContainingNamespace.ToDisplayString() == "Docker.DotNet";
 
-        if (isStjEntryPoint && typeSymbol.TypeArguments.Length > 0)
+        if (!isStjEntryPoint)
         {
-            CheckAndReportType(context, typeSymbol.TypeArguments[0], attribute.GetLocation(), typeSymbol.Name);
+            return;
+        }
+
+        // The mapped type is the first constructor argument: typeof(T).
+        var typeOfArgument = attribute.ArgumentList?.Arguments
+            .Select(arg => arg.Expression)
+            .OfType<TypeOfExpressionSyntax>()
+            .FirstOrDefault();
+
+        if (typeOfArgument == null)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetTypeInfo(typeOfArgument.Type).Type is { } mappedType)
+        {
+            CheckAndReportType(context, mappedType, attribute.GetLocation(), typeSymbol.Name);
         }
     }
 

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -850,6 +850,7 @@ func reflectTypeMembers(t reflect.Type, m *CSModelType) {
 				}
 
 				queryStringParameter := "QueryStringParameter"
+				var leadingArgs []CSArgument
 
 				switch f.Type.Kind() {
 				case reflect.Bool:
@@ -857,10 +858,12 @@ func reflectTypeMembers(t reflect.Type, m *CSModelType) {
 				case reflect.Slice, reflect.Array:
 					queryStringParameter = "QueryStringListParameter"
 				case reflect.Map:
-					queryStringParameter = "QueryStringMapParameter<" + csProp.Type.Name + ">"
+					queryStringParameter = "QueryStringMapParameter"
+					leadingArgs = append(leadingArgs, CSArgument{Value: "typeof(" + csProp.Type.Name + ")"})
 				}
 
 				a := CSAttribute{Type: CSType{"", queryStringParameter}}
+				a.Arguments = append(a.Arguments, leadingArgs...)
 				a.Arguments = append(
 					a.Arguments,
 					CSArgument{


### PR DESCRIPTION
Generic attributes are a .NET 7+ runtime feature. On net48 and other pre net7.0 runtimes, reflecting over `QueryStringMapParameter<T>` throws `System.NotSupportedException` ("Generic types are not valid.") when the query string is built, breaking `ListImagesAsync` and every other call that uses filter/map parameters.

Make the attribute non-generic by passing the mapped type via `typeof` instead of a type parameter:

```
[QueryStringMapParameter<IDictionary<...>>("filters", false)]
[QueryStringMapParameter(typeof(IDictionary<...>), "filters", false)]
```

/cc @Rob-Hague @campersau