### PR TITLE
chore: Add nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Fixes build warnings when multiple package sources are defined locally:

>warning NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source.

Before: Build succeeded with 71 warning(s)
After: Build succeeded